### PR TITLE
Move all classes associated with a specific pack into their own folders

### DIFF
--- a/src/main/java/thePackmaster/actions/dimensiongatepack/SelfDamageAction.java
+++ b/src/main/java/thePackmaster/actions/dimensiongatepack/SelfDamageAction.java
@@ -1,4 +1,4 @@
-package thePackmaster.actions;
+package thePackmaster.actions.dimensiongatepack;
 
 import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;

--- a/src/main/java/thePackmaster/actions/downfallpack/GhostflameOrbEvokeAction.java
+++ b/src/main/java/thePackmaster/actions/downfallpack/GhostflameOrbEvokeAction.java
@@ -3,7 +3,7 @@
 // (powered by FernFlower decompiler)
 //
 
-package thePackmaster.actions;
+package thePackmaster.actions.downfallpack;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.AbstractGameAction.ActionType;

--- a/src/main/java/thePackmaster/actions/legacypack/ShootAnythingAction.java
+++ b/src/main/java/thePackmaster/actions/legacypack/ShootAnythingAction.java
@@ -1,10 +1,10 @@
-package thePackmaster.actions;
+package thePackmaster.actions.legacypack;
 
 import com.badlogic.gdx.graphics.Texture;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import thePackmaster.vfx.ShootAnythingEffect;
+import thePackmaster.vfx.legacypack.ShootAnythingEffect;
 
 public class ShootAnythingAction extends AbstractGameAction {
 

--- a/src/main/java/thePackmaster/cards/dimensiongatepack/Inferno.java
+++ b/src/main/java/thePackmaster/cards/dimensiongatepack/Inferno.java
@@ -5,7 +5,7 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
-import thePackmaster.actions.SelfDamageAction;
+import thePackmaster.actions.dimensiongatepack.SelfDamageAction;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 

--- a/src/main/java/thePackmaster/cards/downfallpack/GhostflameStrike.java
+++ b/src/main/java/thePackmaster/cards/downfallpack/GhostflameStrike.java
@@ -5,7 +5,7 @@ import com.megacrit.cardcrawl.actions.defect.ChannelAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePackmaster.cards.AbstractPackmasterCard;
-import thePackmaster.orbs.Ghostflame;
+import thePackmaster.orbs.downfallpack.Ghostflame;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 import static thePackmaster.util.Wiz.*;

--- a/src/main/java/thePackmaster/cards/downfallpack/ShapersBlessing.java
+++ b/src/main/java/thePackmaster/cards/downfallpack/ShapersBlessing.java
@@ -5,7 +5,7 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.PlatedArmorPower;
 import thePackmaster.cards.AbstractPackmasterCard;
-import thePackmaster.stances.AncientStance;
+import thePackmaster.stances.downfallpack.AncientStance;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 import static thePackmaster.util.Wiz.applyToSelf;

--- a/src/main/java/thePackmaster/cards/legacypack/Cannonball.java
+++ b/src/main/java/thePackmaster/cards/legacypack/Cannonball.java
@@ -6,7 +6,7 @@ import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
-import thePackmaster.actions.ShootAnythingAction;
+import thePackmaster.actions.legacypack.ShootAnythingAction;
 import thePackmaster.cards.AbstractPackmasterCard;
 import thePackmaster.util.TexLoader;
 

--- a/src/main/java/thePackmaster/orbs/downfallpack/Ghostflame.java
+++ b/src/main/java/thePackmaster/orbs/downfallpack/Ghostflame.java
@@ -1,4 +1,4 @@
-package thePackmaster.orbs;
+package thePackmaster.orbs.downfallpack;
 
 import basemod.ReflectionHacks;
 import com.badlogic.gdx.Gdx;
@@ -17,7 +17,7 @@ import com.megacrit.cardcrawl.orbs.AbstractOrb;
 import com.megacrit.cardcrawl.vfx.GhostlyWeakFireEffect;
 import com.megacrit.cardcrawl.vfx.combat.*;
 import com.megacrit.cardcrawl.vfx.combat.OrbFlareEffect.OrbFlareColor;
-import thePackmaster.actions.GhostflameOrbEvokeAction;
+import thePackmaster.actions.downfallpack.GhostflameOrbEvokeAction;
 
 import static thePackmaster.util.Wiz.atb;
 

--- a/src/main/java/thePackmaster/stances/downfallpack/AncientStance.java
+++ b/src/main/java/thePackmaster/stances/downfallpack/AncientStance.java
@@ -1,4 +1,4 @@
-package thePackmaster.stances;
+package thePackmaster.stances.downfallpack;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
@@ -14,7 +14,7 @@ import com.megacrit.cardcrawl.stances.AbstractStance;
 import com.megacrit.cardcrawl.vfx.BorderFlashEffect;
 import com.megacrit.cardcrawl.vfx.combat.IntenseZoomEffect;
 import com.megacrit.cardcrawl.vfx.stance.StanceAuraEffect;
-import thePackmaster.vfx.AncientStanceParticleEffect;
+import thePackmaster.vfx.downfallpack.AncientStanceParticleEffect;
 
 import static thePackmaster.util.Wiz.*;
 import static thePackmaster.SpireAnniversary5Mod.makeID;

--- a/src/main/java/thePackmaster/vfx/downfallpack/AncientStanceParticleEffect.java
+++ b/src/main/java/thePackmaster/vfx/downfallpack/AncientStanceParticleEffect.java
@@ -1,4 +1,4 @@
-package thePackmaster.vfx;
+package thePackmaster.vfx.downfallpack;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;

--- a/src/main/java/thePackmaster/vfx/legacypack/ShootAnythingEffect.java
+++ b/src/main/java/thePackmaster/vfx/legacypack/ShootAnythingEffect.java
@@ -1,4 +1,4 @@
-package thePackmaster.vfx;
+package thePackmaster.vfx.legacypack;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;


### PR DESCRIPTION
The point of this is to make the pattern as clear as possible, so that when contributors add anything of their own (action, card modifier, orb, patch, power, stance, vfx), they are naturally guided towards doing so in their own folder. Things were already mostly set up like that with only around a dozen files out of place.

This was one of the things I noted in my code review, so figured I might as well fix it myself.