### PR TITLE
Added support for custom pack preview background

### DIFF
--- a/src/main/java/thePackmaster/packs/AbstractPackPreviewCard.java
+++ b/src/main/java/thePackmaster/packs/AbstractPackPreviewCard.java
@@ -41,7 +41,7 @@ public abstract class AbstractPackPreviewCard extends CustomCard {
         author = parentPack.author;
         initializeTitle();
         initializeDescription();
-        this.setBackgroundTexture("anniv5Resources/images/512/boosterpackframe.png", "anniv5Resources/images/1024/boosterpackframe.png");
+        setBackgroundTextures();
     }
 
     @Override
@@ -124,5 +124,22 @@ public abstract class AbstractPackPreviewCard extends CustomCard {
         if (!(SingleCardViewPopup.isViewingUpgrade && this.isSeen && !this.isLocked)) {
             renderAuthorText(sb);
         }
+    }
+
+    private void setBackgroundTextures() {
+        String path512 = "";
+        String path1024 = "";
+        String name = parentPack.getClass().getSimpleName();
+        if (!Gdx.files.internal("anniv5Resources/images/512/"+ name +".png").exists()) {
+            path512 = "anniv5Resources/images/512/boosterpackframe.png";
+        } else {
+            path512 = "anniv5Resources/images/512/"+ name +".png";
+        }
+        if (!Gdx.files.internal("anniv5Resources/images/1024/"+ name +".png").exists()) {
+            path1024 = "anniv5Resources/images/1024/boosterpackframe.png";
+        } else {
+            path1024 = "anniv5Resources/images/1024/"+ name +".png";
+        }
+        this.setBackgroundTexture(path512, path1024);
     }
 }


### PR DESCRIPTION
Just support for custom backgrounds for the pack preview card. It doesn't require anyone to do anything different. At the moment it looks for a png file in the 512 and 1024 folders with the same name as the pack classes. Let me know if you want to put them somewhere else or if you want the names to be something different.
Oh, and I didn't include any my the other stuff, but I did test it. It works, as far as I can tell.
![image](https://user-images.githubusercontent.com/104149087/210278746-48d7382c-df94-425a-a2e3-f50a5044f8f7.png)
