### PR TITLE
Mad Science fixes, cannonball to 0

### DIFF
--- a/src/main/java/thePackmaster/actions/madsciencepack/FindCardForAddModifierAction.java
+++ b/src/main/java/thePackmaster/actions/madsciencepack/FindCardForAddModifierAction.java
@@ -1,5 +1,6 @@
 package thePackmaster.actions.madsciencepack;
 
+import basemod.BaseMod;
 import basemod.abstracts.AbstractCardModifier;
 import basemod.helpers.CardModifierManager;
 import com.badlogic.gdx.graphics.Color;
@@ -45,37 +46,44 @@ public class FindCardForAddModifierAction extends AbstractGameAction {
 
     @Override
     public void update() {
-        if (!isDone){
-            Predicate<AbstractCard> combinedRequirements = card -> !card.hasTag(SpireAnniversary5Mod.ISCARDMODIFIED);
-
-            if (requirements != null){
-                combinedRequirements = combinedRequirements.and(requirements);
-            }
+        if (!isDone) {
+            Predicate<AbstractCard> tagCheck = card -> !card.hasTag(SpireAnniversary5Mod.ISCARDMODIFIED);
 
             if (random) {
                 ArrayList<AbstractCard> chosen = new ArrayList<>();
-                ArrayList<AbstractCard> potentialTargets = new ArrayList<>(targetgroup.group);
-                potentialTargets.removeIf(combinedRequirements);
+                ArrayList<AbstractCard> potentialTargets = new ArrayList<>();
+
+                for (AbstractCard c : targetgroup.group) {
+                    if (requirements.and(tagCheck).test(c)) {
+                        potentialTargets.add(c);
+                    }
+                }
                 AbstractCard n;
 
-                if(count >= potentialTargets.size()) {
+                if (count >= potentialTargets.size()) {
                     chosen.addAll(potentialTargets);
                 } else {
                     for (int i = 0; i < count; i++) {
-                        if (potentialTargets.isEmpty()) return; //Sanity check
-                        n = Wiz.getRandomItem(potentialTargets);
-                        potentialTargets.remove(n);
-                        chosen.add(n);
+                        if (potentialTargets.isEmpty()) {
+                            isDone = true;
+                            break;
+                        } else {
+                            n = Wiz.getRandomItem(potentialTargets);
+                            potentialTargets.remove(n);
+                            chosen.add(n);
+                        }
                     }
                 }
 
-                for (AbstractCard c2 : chosen) {
-                    CardModifierManager.addModifier(c2, mod);
-                    c2.superFlash(Color.CHARTREUSE);
+                if (chosen.size() > 0) {
+                    for (AbstractCard c2 : chosen) {
+                        CardModifierManager.addModifier(c2, mod);
+                        c2.superFlash(Color.CHARTREUSE);
+                    }
                 }
             } else {
                 atb(new SelectCardsAction(targetgroup.group, count, uiSTRINGS.TEXT[0], false,
-                        combinedRequirements,
+                        requirements.and(tagCheck),
 
                         (cards) -> {
                             for (AbstractCard c2 : cards) {

--- a/src/main/java/thePackmaster/cards/legacypack/Cannonball.java
+++ b/src/main/java/thePackmaster/cards/legacypack/Cannonball.java
@@ -19,7 +19,7 @@ public class Cannonball extends AbstractPackmasterCard {
     private static final int UPGRADE_BONUS = 2;
 
     public Cannonball() {
-        super(ID, 1, CardType.ATTACK, CardRarity.SPECIAL, CardTarget.ENEMY);
+        super(ID, 0, CardType.ATTACK, CardRarity.SPECIAL, CardTarget.ENEMY);
         this.baseDamage = POWER;
     }
 

--- a/src/main/java/thePackmaster/cards/madsciencepack/Sharpen.java
+++ b/src/main/java/thePackmaster/cards/madsciencepack/Sharpen.java
@@ -23,7 +23,7 @@ public class Sharpen extends AbstractDimensionalCard {
     public void use(AbstractPlayer p, AbstractMonster m)
     {
         dmg(m, AbstractGameAction.AttackEffect.SLASH_VERTICAL);
-        addToBot(new FindCardForAddModifierAction(new AddDamageModifier(magicNumber),1,true, AbstractDungeon.player.hand, card->card.baseDamage>0));
+        addToBot(new FindCardForAddModifierAction(new AddDamageModifier(magicNumber),1,true, AbstractDungeon.player.hand, card->card.type==CardType.ATTACK));
 
     }
 

--- a/src/main/resources/anniv5Resources/localization/eng/madsciencepack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/madsciencepack/Cardstrings.json
@@ -1,7 +1,7 @@
 {
   "${ModID}:Sharpen": {
     "NAME": "Sharpen",
-    "DESCRIPTION": "Deal !D! damage. NL ${ModID}:Modify a random damaging card in hand: 'Add !M! Damage'"
+    "DESCRIPTION": "Deal !D! damage. NL ${ModID}:Modify a random Attack in hand: 'Add !M! Damage'"
   },
   "${ModID}:Fortify": {
     "NAME": "Fortify",


### PR DESCRIPTION
Random choice vs choice predicates were each expecting a different predicate (which cards to look at, vs which cards to remove), resulting in incorrect behavior on which cards get hit.