### PR TITLE
Make Rebound Volley display number of times dynamically

### DIFF
--- a/src/main/resources/anniv5Resources/localization/eng/intothebreachpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/intothebreachpack/Cardstrings.json
@@ -19,7 +19,7 @@
   "${ModID}:ReboundVolley": {
     "NAME": "Rebound Volley",
     "DESCRIPTION": "Deal !D! damage. NL Deal !${ModID}:sd! damage to a random enemy.",
-    "EXTENDED_DESCRIPTION": ["Deal !D! damage. NL Deal !${ModID}:sd! damage to a random enemy twice."]
+    "EXTENDED_DESCRIPTION": ["Deal !D! damage. NL Deal !${ModID}:sd! damage to a random enemy !M! times."]
   },
   "${ModID}:SmokePellets": {
     "NAME": "Smoke Pellets",


### PR DESCRIPTION
For Rebound Volley's branch upgrade, it now says "2 times" instead of "twice". Useful for repeated upgrades