### PR TITLE
Added "Additional Credits" to packs

### DIFF
--- a/src/main/java/thePackmaster/packs/AbstractCardPack.java
+++ b/src/main/java/thePackmaster/packs/AbstractCardPack.java
@@ -1,16 +1,20 @@
 package thePackmaster.packs;
 
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.helpers.CardLibrary;
 import thePackmaster.SpireAnniversary5Mod;
 
 import java.util.ArrayList;
+
+import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public abstract class AbstractCardPack {
     public String packID;
     public String name;
     public String description;
     public String author;
+    public String creditsHeader;
     public String credits;
     public ArrayList<AbstractCard> cards;
     public AbstractCard previewPackCard;
@@ -21,6 +25,7 @@ public abstract class AbstractCardPack {
         this.description = description;
         this.author = author;
         this.credits = credits;
+        this.creditsHeader = CardCrawlGame.languagePack.getUIString(makeID("CreditsRenderStrings")).TEXT[0];
         this.cards = new ArrayList<>();
         initializePack();
     }

--- a/src/main/java/thePackmaster/packs/AbstractCardPack.java
+++ b/src/main/java/thePackmaster/packs/AbstractCardPack.java
@@ -11,16 +11,22 @@ public abstract class AbstractCardPack {
     public String name;
     public String description;
     public String author;
+    public String credits;
     public ArrayList<AbstractCard> cards;
     public AbstractCard previewPackCard;
 
-    public AbstractCardPack(String id, String name, String description, String author) {
+    public AbstractCardPack(String id, String name, String description, String author, String credits) {
         this.packID = id;
         this.name = name;
         this.description = description;
         this.author = author;
+        this.credits = credits;
         this.cards = new ArrayList<>();
         initializePack();
+    }
+
+    public AbstractCardPack(String id, String name, String description, String author) {
+        this(id, name, description, author, null);
     }
 
     public abstract ArrayList<String> getCards();

--- a/src/main/java/thePackmaster/packs/AbstractPackPreviewCard.java
+++ b/src/main/java/thePackmaster/packs/AbstractPackPreviewCard.java
@@ -2,7 +2,6 @@ package thePackmaster.packs;
 
 import basemod.AutoAdd;
 import basemod.abstracts.CustomCard;
-import basemod.helpers.TooltipInfo;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
@@ -13,17 +12,14 @@ import com.evacipated.cardcrawl.modthespire.lib.SpireOverride;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.FontHelper;
-import com.megacrit.cardcrawl.helpers.TipHelper;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.ThePackmaster;
 import thePackmaster.util.CardArtRoller;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static thePackmaster.SpireAnniversary5Mod.*;
+import static thePackmaster.SpireAnniversary5Mod.makeImagePath;
+import static thePackmaster.SpireAnniversary5Mod.modID;
 
 @AutoAdd.Ignore
 public abstract class AbstractPackPreviewCard extends CustomCard {
@@ -146,16 +142,4 @@ public abstract class AbstractPackPreviewCard extends CustomCard {
         }
         this.setBackgroundTexture(path512, path1024);
     }
-
-    /*
-    @Override
-    public List<TooltipInfo> getCustomTooltips() {
-        if (credits != null) {
-            List<TooltipInfo> tips = new ArrayList<>();
-            tips.add(new TooltipInfo(creditsHeader, credits));
-            return tips;
-        }
-        else return null;
-    }
-     */
 }

--- a/src/main/java/thePackmaster/packs/AbstractPackPreviewCard.java
+++ b/src/main/java/thePackmaster/packs/AbstractPackPreviewCard.java
@@ -31,8 +31,6 @@ public abstract class AbstractPackPreviewCard extends CustomCard {
     private static final UIStrings UI_STRINGS = CardCrawlGame.languagePack.getUIString(ID);
     private Color typeColor = new Color(0.35F, 0.35F, 0.35F, 1f);
     protected String author;
-    public String creditsHeader;
-    public String credits;
 
     private boolean needsArtRefresh = false;
 
@@ -45,8 +43,6 @@ public abstract class AbstractPackPreviewCard extends CustomCard {
         rawDescription = parentPack.description;
         name = originalName = parentPack.name;
         author = parentPack.author;
-        creditsHeader = CardCrawlGame.languagePack.getUIString(makeID("CreditsRenderStrings")).TEXT[0];
-        credits = parentPack.credits;
         initializeTitle();
         initializeDescription();
         setBackgroundTextures();

--- a/src/main/java/thePackmaster/packs/AbstractPackPreviewCard.java
+++ b/src/main/java/thePackmaster/packs/AbstractPackPreviewCard.java
@@ -2,6 +2,7 @@ package thePackmaster.packs;
 
 import basemod.AutoAdd;
 import basemod.abstracts.CustomCard;
+import basemod.helpers.TooltipInfo;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
@@ -12,14 +13,17 @@ import com.evacipated.cardcrawl.modthespire.lib.SpireOverride;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.helpers.TipHelper;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.ThePackmaster;
 import thePackmaster.util.CardArtRoller;
 
-import static thePackmaster.SpireAnniversary5Mod.makeImagePath;
-import static thePackmaster.SpireAnniversary5Mod.modID;
+import java.util.ArrayList;
+import java.util.List;
+
+import static thePackmaster.SpireAnniversary5Mod.*;
 
 @AutoAdd.Ignore
 public abstract class AbstractPackPreviewCard extends CustomCard {
@@ -27,6 +31,8 @@ public abstract class AbstractPackPreviewCard extends CustomCard {
     private static final UIStrings UI_STRINGS = CardCrawlGame.languagePack.getUIString(ID);
     private Color typeColor = new Color(0.35F, 0.35F, 0.35F, 1f);
     protected String author;
+    public String creditsHeader;
+    public String credits;
 
     private boolean needsArtRefresh = false;
 
@@ -39,6 +45,8 @@ public abstract class AbstractPackPreviewCard extends CustomCard {
         rawDescription = parentPack.description;
         name = originalName = parentPack.name;
         author = parentPack.author;
+        creditsHeader = CardCrawlGame.languagePack.getUIString(makeID("CreditsRenderStrings")).TEXT[0];
+        credits = parentPack.credits;
         initializeTitle();
         initializeDescription();
         setBackgroundTextures();
@@ -142,4 +150,16 @@ public abstract class AbstractPackPreviewCard extends CustomCard {
         }
         this.setBackgroundTexture(path512, path1024);
     }
+
+    /*
+    @Override
+    public List<TooltipInfo> getCustomTooltips() {
+        if (credits != null) {
+            List<TooltipInfo> tips = new ArrayList<>();
+            tips.add(new TooltipInfo(creditsHeader, credits));
+            return tips;
+        }
+        else return null;
+    }
+     */
 }

--- a/src/main/java/thePackmaster/packs/IntoTheBreachPack.java
+++ b/src/main/java/thePackmaster/packs/IntoTheBreachPack.java
@@ -13,9 +13,10 @@ public class IntoTheBreachPack extends AbstractCardPack {
     public static final String NAME = UI_STRINGS.TEXT[0];
     public static final String DESC = UI_STRINGS.TEXT[1];
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
+    public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public IntoTheBreachPack() {
-        super(ID, NAME, DESC, AUTHOR);
+        super(ID, NAME, DESC, AUTHOR, CREDITS);
     }
 
     @Override

--- a/src/main/java/thePackmaster/screens/PackSetupScreen.java
+++ b/src/main/java/thePackmaster/screens/PackSetupScreen.java
@@ -136,8 +136,7 @@ public class PackSetupScreen extends CustomScreen {
                 TipHelper.renderGenericTip(
                         pack.previewPackCard.hb.x + pack.previewPackCard.hb.width,
                         pack.previewPackCard.hb.y + pack.previewPackCard.hb.height,
-                        ((AbstractPackPreviewCard)pack.previewPackCard).creditsHeader,
-                        pack.credits);
+                        pack.creditsHeader, pack.credits);
             if (pack.previewPackCard.hb.justHovered)
                 CardCrawlGame.sound.playV("CARD_OBTAIN", 0.4F);
 
@@ -158,8 +157,7 @@ public class PackSetupScreen extends CustomScreen {
                     TipHelper.renderGenericTip(
                             pack.previewPackCard.hb.x + pack.previewPackCard.hb.width,
                             pack.previewPackCard.hb.y + pack.previewPackCard.hb.height,
-                            ((AbstractPackPreviewCard)pack.previewPackCard).creditsHeader,
-                            pack.credits);
+                            pack.creditsHeader, pack.credits);
 
                 if (pack.previewPackCard.hb.justHovered)
                     CardCrawlGame.sound.playV("CARD_OBTAIN", 0.4F);

--- a/src/main/java/thePackmaster/screens/PackSetupScreen.java
+++ b/src/main/java/thePackmaster/screens/PackSetupScreen.java
@@ -12,6 +12,8 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.helpers.PowerTip;
+import com.megacrit.cardcrawl.helpers.TipHelper;
 import com.megacrit.cardcrawl.helpers.input.InputHelper;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.random.Random;
@@ -21,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.packs.AbstractCardPack;
+import thePackmaster.packs.AbstractPackPreviewCard;
 
 import java.util.*;
 
@@ -129,6 +132,12 @@ public class PackSetupScreen extends CustomScreen {
             float curDrawScale = pack.previewPackCard.drawScale;
             pack.previewPackCard.updateHoverLogic();
             pack.previewPackCard.drawScale = curDrawScale;
+            if (pack.previewPackCard.hb.hovered && pack.credits != null)
+                TipHelper.renderGenericTip(
+                        pack.previewPackCard.hb.x + pack.previewPackCard.hb.width,
+                        pack.previewPackCard.hb.y + pack.previewPackCard.hb.height,
+                        ((AbstractPackPreviewCard)pack.previewPackCard).creditsHeader,
+                        pack.credits);
             if (pack.previewPackCard.hb.justHovered)
                 CardCrawlGame.sound.playV("CARD_OBTAIN", 0.4F);
 
@@ -145,6 +154,12 @@ public class PackSetupScreen extends CustomScreen {
                 pack.previewPackCard.updateHoverLogic();
                 if (!pack.previewPackCard.hb.hovered)
                     pack.previewPackCard.targetDrawScale = SELECTING_SCALE;
+                else if (pack.credits != null)
+                    TipHelper.renderGenericTip(
+                            pack.previewPackCard.hb.x + pack.previewPackCard.hb.width,
+                            pack.previewPackCard.hb.y + pack.previewPackCard.hb.height,
+                            ((AbstractPackPreviewCard)pack.previewPackCard).creditsHeader,
+                            pack.credits);
 
                 if (pack.previewPackCard.hb.justHovered)
                     CardCrawlGame.sound.playV("CARD_OBTAIN", 0.4F);

--- a/src/main/resources/anniv5Resources/localization/eng/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/UIstrings.json
@@ -62,5 +62,10 @@
       "{0} NL NL Click to view card pool for this run.",
       "Cards available in this run"
     ]
+  },
+  "${ModID}:CreditsRenderStrings": {
+    "TEXT": [
+      "Additional Credits"
+    ]
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/intothebreachpack/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/intothebreachpack/UIstrings.json
@@ -3,7 +3,8 @@
     "TEXT": [
       "Into the Breach",
       "Use powerful mech-based weaponry from the future to dispatch the Spire's threats.",
-      "Enbeon (inspired by Subset Games)"
+      "Enbeon",
+      "#bInto #bthe #bBreach originally created by #bSubset #bGames"
     ]
   }
 }


### PR DESCRIPTION
Added an Additional Credits tooltip that appears when a pack is hovered in the pack selection screen (upon starting a Packmaster run)
To add credits, contributors simply need to add a credits String to their card pack's super() call in its constructor (An example is given, from my Into the Breach pack)
Credits are not required and all previously created packs can be left as is