### PR TITLE
Synergize tweaks

### DIFF
--- a/src/main/java/thePackmaster/cards/coresetpack/Synergize.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/Synergize.java
@@ -48,7 +48,8 @@ public class Synergize extends AbstractPackmasterCard {
         if (AbstractDungeon.actionManager.cardsPlayedThisCombat.size() >= n) {
             AbstractCard c = AbstractDungeon.actionManager.cardsPlayedThisCombat.get(AbstractDungeon.actionManager.cardsPlayedThisCombat.size() - n);
             String parentID = SpireAnniversary5Mod.cardParentMap.get(c.cardID);
-            return !CoreSetPack.ID.equals(parentID);
+            // Cards without a pack shouldn't count as being from a "different pack"
+            return parentID != null && !CoreSetPack.ID.equals(parentID);
         }
         return false;
     }

--- a/src/main/java/thePackmaster/cards/coresetpack/Synergize.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/Synergize.java
@@ -28,7 +28,7 @@ public class Synergize extends AbstractPackmasterCard {
             @Override
             public void update() {
                 isDone = true;
-                if (lastCardDifferentPackCheck()) {
+                if (lastCardDifferentPackCheck(false)) {
                     blck();
                 }
             }
@@ -38,14 +38,15 @@ public class Synergize extends AbstractPackmasterCard {
     @Override
     public void triggerOnGlowCheck() {
         this.glowColor = AbstractCard.BLUE_BORDER_GLOW_COLOR.cpy();
-        if (this.lastCardDifferentPackCheck()) {
+        if (this.lastCardDifferentPackCheck(true)) {
             this.glowColor = AbstractCard.GOLD_BORDER_GLOW_COLOR.cpy();
         }
     }
 
-    private boolean lastCardDifferentPackCheck() {
-        if (AbstractDungeon.actionManager.cardsPlayedThisCombat.size() >= 2) {
-            AbstractCard c = AbstractDungeon.actionManager.cardsPlayedThisCombat.get(AbstractDungeon.actionManager.cardsPlayedThisCombat.size() - 2);
+    private boolean lastCardDifferentPackCheck(boolean forGlow) {
+        int n = forGlow ? 1 : 2;
+        if (AbstractDungeon.actionManager.cardsPlayedThisCombat.size() >= n) {
+            AbstractCard c = AbstractDungeon.actionManager.cardsPlayedThisCombat.get(AbstractDungeon.actionManager.cardsPlayedThisCombat.size() - n);
             String parentID = SpireAnniversary5Mod.cardParentMap.get(c.cardID);
             return !CoreSetPack.ID.equals(parentID);
         }


### PR DESCRIPTION
This has two changes:
* Fixing Synergize's glow check. It had an off-by-one error since it needs to use slightly different logic than the check when the card is played.
* Changing how Synergize works with packless cards (e.g. basics, colorless cards). Previously these triggered the bonus, but that seemed unintended to me. Interpretations on this could differ, but I interpret "the previous card must be from a different pack" as "the previous pack must be in a pack, and that pack must not be the Core Set pack".