### PR TITLE
Replace Pack Rip with Ripped Pecs, balance tweaks for for starter/core relics, balance tweaks for my packs

### DIFF
--- a/src/main/java/thePackmaster/cards/coresetpack/PackRip.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/PackRip.java
@@ -18,12 +18,15 @@ import java.util.ArrayList;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
+// This card used to be in the Core Set pack but no longer is
+// However, we've kept it around since we may want to give it to the player from a Packmaster-specific event
+// (with an appropriate cost, like an unremovable curse)
 public class PackRip extends AbstractPackmasterCard {
     public final static String ID = makeID("PackRip");
     // intellij stuff skill, self, basic, , ,  5, 3, ,
 
     public PackRip() {
-        super(ID, 1, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
+        super(ID, 1, CardType.SKILL, CardRarity.SPECIAL, CardTarget.SELF);
         exhaust = true;
     }
 

--- a/src/main/java/thePackmaster/cards/coresetpack/RippedPecs.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/RippedPecs.java
@@ -1,0 +1,62 @@
+package thePackmaster.cards.coresetpack;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.localization.CardStrings;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.StrengthPower;
+import thePackmaster.SpireAnniversary5Mod;
+import thePackmaster.cards.AbstractPackmasterCard;
+import thePackmaster.util.Wiz;
+
+import java.util.HashSet;
+
+import static thePackmaster.SpireAnniversary5Mod.makeID;
+
+public class RippedPecs extends AbstractPackmasterCard {
+    public final static String ID = makeID("RippedPecs");
+    private static final CardStrings cardStrings = CardCrawlGame.languagePack.getCardStrings(ID);
+
+    public RippedPecs() {
+        super(ID, 1, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
+        this.exhaust = true;
+    }
+
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        this.addToBot(new AbstractGameAction() {
+            @Override
+            public void update() {
+                int strength = getPacksPlayedThisCombat(false);
+                Wiz.applyToSelfTop(new StrengthPower(p, strength));
+                this.isDone = true;
+            }
+        });
+    }
+
+    public void upp() {
+        this.exhaust = false;
+    }
+
+    @Override
+    public void applyPowers() {
+        this.rawDescription = (this.upgraded ? cardStrings.UPGRADE_DESCRIPTION : cardStrings.DESCRIPTION) + cardStrings.EXTENDED_DESCRIPTION[0].replace("{0}", this.getPacksPlayedThisCombat(true) + "");
+        this.initializeDescription();
+    }
+
+    private int getPacksPlayedThisCombat(boolean forApplyPowers) {
+        int n = forApplyPowers ? 1 : 2;
+        HashSet<String> packs = new HashSet<>();
+        if (AbstractDungeon.actionManager.cardsPlayedThisCombat.size() >= n) {
+            for (AbstractCard c : AbstractDungeon.actionManager.cardsPlayedThisCombat.subList(0, AbstractDungeon.actionManager.cardsPlayedThisCombat.size() - n + 1)) {
+                String parentID = SpireAnniversary5Mod.cardParentMap.get(c.cardID);
+                if (parentID != null) {
+                    packs.add(parentID);
+                }
+            }
+        }
+        return packs.size();
+    }
+}

--- a/src/main/java/thePackmaster/cards/utilitypack/GreaterHex.java
+++ b/src/main/java/thePackmaster/cards/utilitypack/GreaterHex.java
@@ -19,7 +19,7 @@ public class GreaterHex extends AbstractPackmasterCard {
     public static final String NAME = cardStrings.NAME;
     public static final String DESCRIPTION = cardStrings.DESCRIPTION;
     private static final int COST = 0;
-    private static final int STATS = 3;
+    private static final int STATS = 2;
     private static final int UPGRADE_STATS = 1;
 
     public GreaterHex() {

--- a/src/main/java/thePackmaster/cards/utilitypack/PlasmaShield.java
+++ b/src/main/java/thePackmaster/cards/utilitypack/PlasmaShield.java
@@ -17,7 +17,7 @@ public class PlasmaShield extends AbstractPackmasterCard {
     public static final String NAME = cardStrings.NAME;
     public static final String DESCRIPTION = cardStrings.DESCRIPTION;
     private static final int COST = 2;
-    private static final int AMOUNT = 5;
+    private static final int AMOUNT = 3;
     private static final int UPGRADE_AMOUNT = 2;
     private static final int PLASMA = 1;
 

--- a/src/main/java/thePackmaster/packs/CoreSetPack.java
+++ b/src/main/java/thePackmaster/packs/CoreSetPack.java
@@ -27,7 +27,7 @@ public class CoreSetPack extends AbstractCardPack {
         cards.add(DestinyDraw.ID);
         cards.add(Flick.ID);
         cards.add(MayhemForm.ID);
-        cards.add(PackRip.ID);
+        cards.add(RippedPecs.ID);
         cards.add(Showoff.ID);
         cards.add(Sideboard.ID);
         cards.add(SmithingHammer.ID);

--- a/src/main/java/thePackmaster/relics/CollectorBadge.java
+++ b/src/main/java/thePackmaster/relics/CollectorBadge.java
@@ -36,6 +36,7 @@ public class CollectorBadge extends AbstractPackmasterRelic {
     public void onVictory() {
         usedPacks.clear();
         setDescriptionAfterLoading();
+        stopPulse();
         counter = -1;
     }
 

--- a/src/main/java/thePackmaster/relics/CollectorBadge.java
+++ b/src/main/java/thePackmaster/relics/CollectorBadge.java
@@ -59,7 +59,7 @@ public class CollectorBadge extends AbstractPackmasterRelic {
             if (!usedPacks.contains(Wiz.getPackByCard(c).name)) {
                 usedPacks.add(Wiz.getPackByCard(c).name);
                 counter++;
-                if (!pulse && usedPacks.size() >= 3) {
+                if (!pulse && usedPacks.size() >= 4) {
                     beginLongPulse();
                 }
                 setDescriptionAfterLoading();
@@ -69,7 +69,7 @@ public class CollectorBadge extends AbstractPackmasterRelic {
 
     private void setDescriptionAfterLoading() {
 
-        if (usedPacks.size() > 2) {
+        if (usedPacks.size() > 3) {
             description = DESCRIPTIONS[0] + DESCRIPTIONS[2];
         } else if (usedPacks.size() > 0) {
             String st = usedPacks.get(0);

--- a/src/main/java/thePackmaster/relics/HandyHaversack.java
+++ b/src/main/java/thePackmaster/relics/HandyHaversack.java
@@ -10,10 +10,10 @@ public class HandyHaversack extends AbstractPackmasterRelic {
     public static final String ID = makeID("HandyHaversack");
     private boolean firstTurn = true;
 
+
     public HandyHaversack() {
         super(ID, RelicTier.STARTER, LandingSound.FLAT);
     }
-
 
     public void atPreBattle() {
         this.firstTurn = true;
@@ -28,7 +28,7 @@ public class HandyHaversack extends AbstractPackmasterRelic {
                 addToTop(new com.megacrit.cardcrawl.actions.common.GainEnergyAction(1));
             }
             if (count >= 20) {
-                addToTop(new com.megacrit.cardcrawl.actions.common.DrawCardAction(2));
+                addToTop(new com.megacrit.cardcrawl.actions.common.DrawCardAction(1));
             }
             this.firstTurn = false;
         }

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -39,7 +39,7 @@
     "NAME": "Handy Haversack",
     "FLAVOR": "TODO: make this a sweet relic.",
     "DESCRIPTIONS": [
-      "At the start of each combat: NL Gain [E] if you have 10 or cards in your deck. NL Draw 2 cards if you have 20 or more cards in your deck."
+      "At the start of each combat: NL Gain [E] if you have 10 or cards in your deck. NL Draw 1 card if you have 20 or more cards in your deck."
     ]
   },
   "${ModID}:PMBoosterBox": {

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -22,7 +22,7 @@
     "NAME": "Collector Badge",
     "FLAVOR": "TODO: make this a sweet relic.",
     "DESCRIPTIONS": [
-      "At the start of each turn, if you played a card from 3 different Booster Packs the previous turn, gain [E] .",
+      "At the start of each turn, if you played a card from 4 different Booster Packs the previous turn, gain [E] .",
       " NL NL Packs used this turn: ",
       " NL NL This will trigger next turn. "
     ]

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
@@ -25,6 +25,12 @@
     "DESCRIPTION": "Discard your hand, then choose 1 of 3 Packs. Add its cards to your hand. NL Exhaust.",
     "UPGRADE_DESCRIPTION": "Discard your hand, then choose 1 of 3 Packs. Add its cards to your hand and Upgrade them. NL Exhaust."
   },
+  "${ModID}:RippedPecs": {
+    "NAME": "Ripped Pecs",
+    "DESCRIPTION": "Gain 1 Strength for each pack you've played a card from this combat. NL Exhaust.",
+    "UPGRADE_DESCRIPTION": "Gain 1 Strength for each pack you've played a card from this combat.",
+    "EXTENDED_DESCRIPTION": [" NL (Gains {0} Strength.)"]
+  },
   "${ModID}:Showoff": {
     "NAME": "Showoff",
     "DESCRIPTION": "Gain !B! Block. NL Next turn, draw 2 additional cards."


### PR DESCRIPTION
The list of commits should summarize the individual changes well.

Having played with Ripped Pecs in a run, I don't think it's overpowered at all (and neither did most of the people discussing it yesterday). I also like having actual scaling of some form in the core set pack, since otherwise it's entirely lacking. If people end up not liking Ripped Pecs in its current form, it can always be reworked to use a threshold instead (e.g. gain 4 strength if you've played cards from more than 4 packs this combat).