### PR TITLE
Core relics: fix Collector's Badge not resetting its counter at the start of each turn

### DIFF
--- a/src/main/java/thePackmaster/relics/CollectorBadge.java
+++ b/src/main/java/thePackmaster/relics/CollectorBadge.java
@@ -43,12 +43,12 @@ public class CollectorBadge extends AbstractPackmasterRelic {
     @Override
     public void atTurnStart() {
         if (pulse) {
-            counter = 0;
             flash();
             Wiz.atb(new RelicAboveCreatureAction(Wiz.p(), this));
             addToBot(new GainEnergyAction(1));
             stopPulse();
         }
+        counter = 0;
         usedPacks.clear();
         setDescriptionAfterLoading();
     }


### PR DESCRIPTION
Just ran into this bug. It's been here all along, just didn't notice it the previous time I touched this relic because I was triggering it almost every turn.