### PR TITLE
Warlock pack: switch Imp to use a different system that better matches how we want it to work

### DIFF
--- a/src/main/java/thePackmaster/cards/warlockpack/Imp.java
+++ b/src/main/java/thePackmaster/cards/warlockpack/Imp.java
@@ -3,6 +3,7 @@ package thePackmaster.cards.warlockpack;
 import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.AutoplayField;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DrawCardAction;
+import com.megacrit.cardcrawl.actions.utility.NewQueueCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -19,10 +20,12 @@ import static thePackmaster.util.Wiz.thornDmg;
 public class Imp extends AbstractPackmasterCard {
     public final static String ID = makeID(Imp.class.getSimpleName());
 
-    private static final int COST = 0;
+    private static final int COST = -2;
     private static final int DAMAGE = 4;
     private static final int DAMAGE_INCREASE = 1;
     private static final int UPGRADE_DAMAGE_INCREASE = 1;
+
+    public static int ImpDamageBonus = 0;
 
     public Imp() {
         super(ID, COST, AbstractCard.CardType.SKILL, AbstractCard.CardRarity.SPECIAL, AbstractCard.CardTarget.ALL_ENEMY, CardColor.COLORLESS);
@@ -40,6 +43,8 @@ public class Imp extends AbstractPackmasterCard {
         atb(new AbstractGameAction() {
             @Override
             public void update() {
+                ImpDamageBonus += secondMagic;
+
                 List<AbstractCard> cards = new ArrayList<>();
                 cards.addAll(AbstractDungeon.player.hand.group);
                 cards.addAll(AbstractDungeon.player.drawPile.group);
@@ -64,8 +69,13 @@ public class Imp extends AbstractPackmasterCard {
 
     @Override
     public void applyPowers() {
-        int impsThisCombat = (int)AbstractDungeon.actionManager.cardsPlayedThisCombat.stream().filter(c -> c instanceof Imp).count();
-        this.magicNumber = this.baseMagicNumber = DAMAGE + impsThisCombat;
-        this.isMagicNumberModified = impsThisCombat > 0;
+        this.magicNumber = this.baseMagicNumber = DAMAGE + ImpDamageBonus;
+        this.isMagicNumberModified = ImpDamageBonus > 0;
+    }
+
+    public void triggerWhenAddedToHand() {
+        this.dontTriggerOnUseCard = true;
+        this.applyPowers();
+        this.addToBot(new NewQueueCardAction(this, true, false, true));
     }
 }

--- a/src/main/java/thePackmaster/patches/warlockpack/ImpCanUsePatch.java
+++ b/src/main/java/thePackmaster/patches/warlockpack/ImpCanUsePatch.java
@@ -1,0 +1,28 @@
+package thePackmaster.patches.warlockpack;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireInstrumentPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import javassist.CannotCompileException;
+import javassist.expr.ExprEditor;
+import javassist.expr.FieldAccess;
+import thePackmaster.cards.warlockpack.Imp;
+
+@SpirePatch(clz = AbstractCard.class, method = "canUse", paramtypez = {AbstractPlayer.class, AbstractMonster.class })
+public class ImpCanUsePatch {
+    public static class ImpCanUseExprEditor extends ExprEditor {
+        @Override
+        public void edit(FieldAccess fieldAccess) throws CannotCompileException {
+            if (fieldAccess.getClassName().equals(AbstractCard.class.getName()) && fieldAccess.getFieldName().equals("costForTurn")) {
+                fieldAccess.replace(String.format("{ $_ = $0 instanceof %1$s ? 0 : $proceed($$); }", Imp.class.getName()));
+            }
+        }
+    }
+
+    @SpireInstrumentPatch
+    public static ExprEditor impCanUsePatch() {
+        return new ImpCanUseExprEditor();
+    }
+}

--- a/src/main/java/thePackmaster/patches/warlockpack/ImpPreventPlayOrGlowInHandPatch.java
+++ b/src/main/java/thePackmaster/patches/warlockpack/ImpPreventPlayOrGlowInHandPatch.java
@@ -1,0 +1,31 @@
+package thePackmaster.patches.warlockpack;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireInstrumentPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import javassist.CannotCompileException;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+import thePackmaster.cards.warlockpack.Imp;
+
+@SpirePatch(clz = AbstractPlayer.class, method = "updateSingleTargetInput")
+@SpirePatch(clz = AbstractPlayer.class, method = "clickAndDragCards")
+@SpirePatch(clz = AbstractPlayer.class, method = "releaseCard")
+@SpirePatch(clz = CardGroup.class, method = "glowCheck")
+public class ImpPreventPlayOrGlowInHandPatch {
+    public static class ImpDontGlowInHandExprEditor extends ExprEditor {
+        @Override
+        public void edit(MethodCall methodCall) throws CannotCompileException {
+            if (methodCall.getClassName().equals(AbstractCard.class.getName()) && methodCall.getMethodName().equals("canUse")) {
+                methodCall.replace(String.format("{ $_ = !($0 instanceof %1$s) && $proceed($$); }", Imp.class.getName()));
+            }
+        }
+    }
+
+    @SpireInstrumentPatch
+    public static ExprEditor impDontGlowInHandPatch() {
+        return new ImpDontGlowInHandExprEditor();
+    }
+}

--- a/src/main/java/thePackmaster/patches/warlockpack/ResetImpDamageBonusPatch.java
+++ b/src/main/java/thePackmaster/patches/warlockpack/ResetImpDamageBonusPatch.java
@@ -1,0 +1,25 @@
+package thePackmaster.patches.warlockpack;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import thePackmaster.cards.warlockpack.Imp;
+
+public class ResetImpDamageBonusPatch {
+    @SpirePatch(clz = AbstractPlayer.class, method = "applyStartOfCombatLogic")
+    public static class StartOfCombatPatch {
+        @SpirePrefixPatch
+        public static void startOfCombat(AbstractPlayer __instance) {
+            Imp.ImpDamageBonus = 0;
+        }
+    }
+
+    @SpirePatch(clz = AbstractPlayer.class, method = "onVictory")
+    public static class EndOfCombatPatch {
+        @SpirePostfixPatch
+        public static void endOfCombat(AbstractPlayer __instance) {
+            Imp.ImpDamageBonus = 0;
+        }
+    }
+}

--- a/src/main/java/thePackmaster/patches/warlockpack/TriggerImpOnAddToHandPatch.java
+++ b/src/main/java/thePackmaster/patches/warlockpack/TriggerImpOnAddToHandPatch.java
@@ -1,0 +1,21 @@
+package thePackmaster.patches.warlockpack;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import thePackmaster.cards.warlockpack.Imp;
+
+@SpirePatch(clz = CardGroup.class, method = "addToHand")
+@SpirePatch(clz = CardGroup.class, method = "addToTop")
+@SpirePatch(clz = CardGroup.class, method = "addToBottom")
+@SpirePatch(clz = CardGroup.class, method = "addToRandomSpot")
+public class TriggerImpOnAddToHandPatch {
+    @SpirePostfixPatch
+    public static void trigger(CardGroup __instance, AbstractCard c) {
+        if (AbstractDungeon.player != null && __instance == AbstractDungeon.player.hand && c instanceof Imp) {
+            ((Imp)c).triggerWhenAddedToHand();
+        }
+    }
+}

--- a/src/main/resources/anniv5Resources/localization/eng/warlockpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/warlockpack/Cardstrings.json
@@ -1,7 +1,7 @@
 {
   "${ModID}:Imp": {
     "NAME": "Imp",
-    "DESCRIPTION": "Autoplay. NL Deal !M! damage to a random enemy. Increase the damage of *Imp cards by 1 this combat. Draw a card. NL Exhaust."
+    "DESCRIPTION": "${ModID}:Casts\u00a0When\u00a0Drawn. NL Deal !M! damage to a random enemy. Increase the damage of *Imp cards by 1 this combat. Draw a card. NL Exhaust."
   },
   "${ModID}:HighPriestessJeklik": {
     "NAME": "High Priestess Jeklik",

--- a/src/main/resources/anniv5Resources/localization/eng/warlockpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/warlockpack/Keywordstrings.json
@@ -1,0 +1,7 @@
+[
+  {
+    "PROPER_NAME": "Casts\u00a0When\u00a0Drawn",
+    "NAMES": ["casts\u00a0when\u00a0drawn"],
+    "DESCRIPTION": "When drawn or put into your hand, activate this card's effects. (This does not trigger on play effects such as Beat of Death.)"
+  }
+]


### PR DESCRIPTION
This code is adapted from a mechanic I made but never put in any released mod. It's similar to Autoplay, but has the following differences (which are pretty important when you put them all together):
* It uses the card queue for consistency but does not count as playing a card (because it sets `dontTriggeronUseCard`, see `Imp.triggerWhenAddedToHand`). This means that you don't get screwed over by Gremlin Nob's Enrage or the Heart's Beat of Death, both of which have always made me hate having Autoplay cards in my deck.
* The effect triggers no matter how the card is added to your hand, see `TriggerImpOnAddToHandPatch`. I've always felt that Autoplay cards only triggering when drawn was unintuitive when applied to the cards I wanted to make (it may be what people want for some cards, but I've always felt it was a poor fit for anything I tried to do).
* Together with some other patches (ImpCanUsePatch, ImpPreventPlayOrGlowInHandPatch), this lets you make Autoplay cards that are costless (like Unplayable cards) without odd UI interactions (like glowing when they shouldn't or being playable if you click fast enough).
* Another plus of this approach is that it makes the cards execute their effects faster, which is a great side benefit.

All this is basically the functionality Diamsword and I were looking for from the start, but I didn't remember how quirky Autoplay was and how many ways it differed from our desired approach.

Since this was taken from another mod, I've done a fair amount of testing of the patches (in a form that used a different card instead of Imp). I just translated them to reference Imp and then had to rework Imp damage scaling to fit with the new system. That included making a patch for resetting things at the start and end of combat that could have been two subscribers instead (making the patch was faster since I knew the exact locations and code to patch).

The patches generally have `instanceof` checks for Imp to avoid affecting other cards.

The name Casts When Drawn is from the Hearthstone mechanic that does exactly this.