### PR TITLE
Sort packs alphabetically and add wide potions support with reflection

### DIFF
--- a/src/main/java/thePackmaster/patches/CompendiumPatches.java
+++ b/src/main/java/thePackmaster/patches/CompendiumPatches.java
@@ -70,10 +70,10 @@ public class CompendiumPatches {
 
         public static String getParnetNameFromObject(Object o) {
             if(o instanceof AbstractCard) {
-                String s = SpireAnniversary5Mod.cardParentMap.get(((AbstractCard) o).cardID);
-                if(s == null)
+                String packId = SpireAnniversary5Mod.cardParentMap.get(((AbstractCard) o).cardID);
+                if(packId == null)
                     return "ZZZZZZZ";
-                return s;
+                return SpireAnniversary5Mod.packsByID.get(packId).name;
             }
             return "ZZZZZZZ";
         }

--- a/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
+++ b/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
@@ -21,7 +21,9 @@ import thePackmaster.ui.PackFilterMenu;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -64,7 +66,9 @@ public class MainMenuUIPatch {
     static {
         options.add(TEXT[2]);
         options.add(TEXT[3]);
-        for (AbstractCardPack c : SpireAnniversary5Mod.unfilteredAllPacks) {
+        List<AbstractCardPack> sortedPacks = new ArrayList<>(SpireAnniversary5Mod.unfilteredAllPacks);
+        sortedPacks.sort(Comparator.comparing((pack)->pack.name));
+        for (AbstractCardPack c : sortedPacks) {
             options.add(c.name);
         }
 
@@ -74,7 +78,7 @@ public class MainMenuUIPatch {
         idToIndex.put(RANDOM, 0);
         idToIndex.put(CHOICE, 1);
         for (int i = 2; i < optionIDs.length; ++i) {
-            String packID = SpireAnniversary5Mod.unfilteredAllPacks.get(i - 2).packID;
+            String packID = sortedPacks.get(i - 2).packID;
             optionIDs[i] = packID;
             idToIndex.put(packID, i);
         }

--- a/src/main/java/thePackmaster/screens/PackSetupScreen.java
+++ b/src/main/java/thePackmaster/screens/PackSetupScreen.java
@@ -175,7 +175,7 @@ public class PackSetupScreen extends CustomScreen {
                     genericScreenOverlayReset();
                     AbstractDungeon.closeCurrentScreen();
 
-                    currentPoolPacks.sort(Comparator.comparing((pack)->pack.packID));
+                    currentPoolPacks.sort(Comparator.comparing((pack)->pack.name));
                     SpireAnniversary5Mod.selectedCards = true;
                     editPotionPool();
                     CardCrawlGame.dungeon.initializeCardPools();

--- a/src/main/java/thePackmaster/ui/PackFilterMenu.java
+++ b/src/main/java/thePackmaster/ui/PackFilterMenu.java
@@ -17,6 +17,8 @@ import thePackmaster.packs.AbstractCardPack;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 public class PackFilterMenu {
 
@@ -48,7 +50,9 @@ public class PackFilterMenu {
     public PackFilterMenu() {
         BaseMod.logger.info("Settings.HEIGHT = " + Settings.HEIGHT);
         ArrayList<String> optionNames = new ArrayList<>();
-        for (AbstractCardPack pack : SpireAnniversary5Mod.unfilteredAllPacks) {
+        List<AbstractCardPack> sortedPacks = new ArrayList<>(SpireAnniversary5Mod.unfilteredAllPacks);
+        sortedPacks.sort(Comparator.comparing((pack)->pack.name));
+        for (AbstractCardPack pack : sortedPacks) {
             packs.add(pack);
             optionNames.add(pack.name);
         }


### PR DESCRIPTION
There are a few packs where the name and ID don't match, and in theory if this ever gets translated sorting by name is better, so I found the places I knew about where packs were sorted and changed them.

For the wide potions support, you can see what I did in the main mod file. Doing things with reflection like this lets you have optional support for other mods without making them any kind of dependency, hard or soft. It's more complex to set up, but I think it's worth it and have done this in others mods I've created. I did test that wide potions worked for the four Michael created, but didn't do any of the other stuff wide potions can do (like customizing their names or descriptions for the wide versions).