### PR TITLE
Change Banishing Decree to select from 5 packs and make the player able to reopen the shop after buying it

### DIFF
--- a/src/main/java/thePackmaster/relics/BanishingDecree.java
+++ b/src/main/java/thePackmaster/relics/BanishingDecree.java
@@ -7,16 +7,13 @@ import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import com.megacrit.cardcrawl.helpers.FontHelper;
 import com.megacrit.cardcrawl.helpers.PowerTip;
 import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.rewards.RewardItem;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.rooms.ShopRoom;
 import thePackmaster.SpireAnniversary5Mod;
-import thePackmaster.ThePackmaster;
 import thePackmaster.packs.AbstractCardPack;
-import thePackmaster.packs.AbstractPackPreviewCard;
 import thePackmaster.util.Wiz;
 
 import java.util.ArrayList;

--- a/src/main/java/thePackmaster/relics/BanishingDecree.java
+++ b/src/main/java/thePackmaster/relics/BanishingDecree.java
@@ -5,9 +5,11 @@ import basemod.abstracts.CustomSavable;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.FontHelper;
 import com.megacrit.cardcrawl.helpers.PowerTip;
+import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.rewards.RewardItem;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.rooms.ShopRoom;
@@ -18,6 +20,8 @@ import thePackmaster.packs.AbstractPackPreviewCard;
 import thePackmaster.util.Wiz;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static thePackmaster.SpireAnniversary5Mod.*;
 
@@ -89,8 +93,12 @@ public class BanishingDecree extends AbstractPackmasterRelic implements CustomSa
                 BaseMod.logger.info("Banned Pack" + bannedPack);
                 SpireAnniversary5Mod.currentPoolPacks.remove(cp);
                 AbstractDungeon.gridSelectScreen.selectedCards.clear();
+
+                List<AbstractCard> allOtherPackPreviewCards = SpireAnniversary5Mod.getPreviewCardsNotFromCurrentSet();
+                Collections.shuffle(allOtherPackPreviewCards, new Random(Settings.seed).random);
                 CardGroup tmp = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
-                for (AbstractCard c : SpireAnniversary5Mod.getPreviewCardsNotFromCurrentSet()) {
+                for (int i = 0; i < 5; i++) {
+                    AbstractCard c = allOtherPackPreviewCards.get(i);
                     if (c != cp.previewPackCard) tmp.addToTop(c);
                 }
                 AbstractDungeon.gridSelectScreen.open(tmp,

--- a/src/main/java/thePackmaster/relics/BanishingDecree.java
+++ b/src/main/java/thePackmaster/relics/BanishingDecree.java
@@ -112,7 +112,6 @@ public class BanishingDecree extends AbstractPackmasterRelic implements CustomSa
                 BaseMod.logger.info("New Pack" + newPack);
                 SpireAnniversary5Mod.currentPoolPacks.add(cp);
                 CardCrawlGame.dungeon.initializeCardPools();
-                AbstractDungeon.getCurrRoom().phase = AbstractRoom.RoomPhase.COMPLETE;
 
                 AbstractDungeon.gridSelectScreen.selectedCards.clear();
                 setDescriptionAfterLoading();
@@ -128,7 +127,7 @@ public class BanishingDecree extends AbstractPackmasterRelic implements CustomSa
                 }
 
                 skipDefaultCardRewards = true;
-                AbstractDungeon.combatRewardScreen.open();
+                AbstractDungeon.combatRewardScreen.open(this.DESCRIPTIONS[6]);
                 skipDefaultCardRewards = false;
                 AbstractDungeon.getCurrRoom().rewardPopOutTimer = 0.0F;
 

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -15,7 +15,8 @@
       "Cards from the Pack '",
       "' will no longer appear in card rewards.",
       "' will appear in card rewards.",
-      "Choose a Pack to gain with "
+      "Choose a Pack to gain with ",
+      "Power!"
     ]
   },
   "${ModID}:CollectorBadge": {

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -10,7 +10,7 @@
     "NAME": "Banishing Decree",
     "FLAVOR": "Absorb what is useful, reject what is useless and add what is essentially your own.",
     "DESCRIPTIONS": [
-      "Upon pickup, choose one of your Packs. Cards from it will no longer appear in card rewards. Then, choose a new Pack to replace it with, and gain up to 3 card rewards from that pack.",
+      "Upon pickup, choose one of your Packs. Cards from it will no longer appear in card rewards. Then, choose #b1 of #b5 new Packs to replace it with, and gain up to #b3 card rewards from that pack.",
       "Choose a Pack to banish with ",
       "Cards from the Pack '",
       "' will no longer appear in card rewards.",


### PR DESCRIPTION
Selecting 1 out of 5 feels so much better to me. Instead of needing to process 30+ packs and thinking "hm, which pack is the most universally broken thing", the decision is now "hm, which of these 5 packs goes well with my deck so far and my other packs".

For the bug fix, Banishing Decree should now work the same as Orrery, you have to click a few times but a cancel button will show up. Turns out that the switch for whether that shows up is based on whether you pass a custom label when you open the rewards screen. Who knew?

![image](https://user-images.githubusercontent.com/62083413/212499397-23a9d5f2-00eb-4b9e-ae11-49512dcbfdf5.png)
