### PR TITLE
Fixes and tweaks from today's development and playtesting

### DIFF
--- a/src/main/java/thePackmaster/cards/aggressionpack/DarkLance.java
+++ b/src/main/java/thePackmaster/cards/aggressionpack/DarkLance.java
@@ -17,7 +17,7 @@ public class DarkLance extends AbstractAggressionCard {
     public static final String ID = SpireAnniversary5Mod.makeID("DarkLance");
     private static final int COST = 1;
     private static final int DAMAGE = 9;
-    private static final int UPGRADE_DAMAGE = 1;
+    private static final int UPGRADE_DAMAGE = 2;
     private static final int DRAW = 2;
     private static final int UPGRADE_DRAW = 1;
 

--- a/src/main/java/thePackmaster/cards/aggressionpack/InnerFury.java
+++ b/src/main/java/thePackmaster/cards/aggressionpack/InnerFury.java
@@ -14,7 +14,7 @@ import thePackmaster.stances.aggressionpack.AggressionStance;
 public class InnerFury extends AbstractAggressionCard {
     public static final String ID = SpireAnniversary5Mod.makeID("InnerFury");
     private static final int COST = 1;
-    private static final int TEMP_STRENGTH_AND_BLOCK = 3;
+    private static final int TEMP_STRENGTH_AND_BLOCK = 4;
     private static final int UPGRADE_TEMP_STRENGTH_AND_BLOCK = 2;
 
     public InnerFury() {

--- a/src/main/java/thePackmaster/cards/aggressionpack/Vindicate.java
+++ b/src/main/java/thePackmaster/cards/aggressionpack/Vindicate.java
@@ -16,7 +16,7 @@ public class Vindicate extends AbstractAggressionCard {
     public static final String ID = SpireAnniversary5Mod.makeID("Vindicate");
     private static final int COST = 1;
     private static final int DAMAGE = 7;
-    private static final int UPGRADE_DAMAGE = 1;
+    private static final int UPGRADE_DAMAGE = 2;
     private static final int RAGE = 4;
     private static final int UPGRADE_RAGE = 2;
 

--- a/src/main/java/thePackmaster/cards/clawpack/Alclawmize.java
+++ b/src/main/java/thePackmaster/cards/clawpack/Alclawmize.java
@@ -22,6 +22,7 @@ public class Alclawmize extends AbstractClawCard {
     public Alclawmize() {
         super(ID, 1, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
         exhaust=true;
+        tags.add(CardTags.HEALING);
 
         potions.add(AttackPotionButClaw.POTION_ID);
         potions.add(ClawPowerPotion.POTION_ID);

--- a/src/main/java/thePackmaster/cards/dimensiongatepack/PackRat.java
+++ b/src/main/java/thePackmaster/cards/dimensiongatepack/PackRat.java
@@ -24,6 +24,7 @@ public class PackRat extends AbstractDimensionalCard {
         baseBlock = 14;
         setFrame("packratframe.png");
         FleetingField.fleeting.set(this, true);
+        tags.add(CardTags.HEALING);
     }
 
 

--- a/src/main/java/thePackmaster/cards/legacypack/PoisonMastery.java
+++ b/src/main/java/thePackmaster/cards/legacypack/PoisonMastery.java
@@ -19,6 +19,7 @@ public class PoisonMastery extends AbstractLegacyCard {
     public PoisonMastery() {
         super(ID, 1, CardType.POWER, CardRarity.RARE, CardTarget.SELF);
         baseMagicNumber = magicNumber = 1;
+        tags.add(CardTags.HEALING);
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/prismaticpack/GrabBag.java
+++ b/src/main/java/thePackmaster/cards/prismaticpack/GrabBag.java
@@ -16,7 +16,7 @@ public class GrabBag extends AbstractPrismaticCard {
     public static final String ID = SpireAnniversary5Mod.makeID("GrabBag");
     private static final int COST = 1;
     private static final int UPGRADE_COST = 0;
-    private static final int CARDS = 3;
+    private static final int CARDS = 4;
 
     public GrabBag() {
         super(ID, COST, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);

--- a/src/main/java/thePackmaster/cards/startuppack/BattlePrep.java
+++ b/src/main/java/thePackmaster/cards/startuppack/BattlePrep.java
@@ -21,6 +21,7 @@ public class BattlePrep extends AbstractStartUpCard {
     public BattlePrep() {
         super(ID, 2, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
         FleetingField.fleeting.set(this, true);
+        tags.add(CardTags.HEALING);
     }
 
     @Override

--- a/src/main/java/thePackmaster/cards/utilitypack/Enrage.java
+++ b/src/main/java/thePackmaster/cards/utilitypack/Enrage.java
@@ -14,7 +14,7 @@ import thePackmaster.stances.aggressionpack.AggressionStance;
 public class Enrage extends AbstractUtilityCard {
     public static final String ID = SpireAnniversary5Mod.makeID("Enrage");
     private static final int COST = 1;
-    private static final int DRAW = 1;
+    private static final int DRAW = 2;
     private static final int UPGRADE_DRAW = 1;
     private static final int DISCARD = 2;
 

--- a/src/main/java/thePackmaster/cards/utilitypack/PlasmaShield.java
+++ b/src/main/java/thePackmaster/cards/utilitypack/PlasmaShield.java
@@ -14,7 +14,7 @@ import thePackmaster.powers.utilitypack.PlasmaShieldPower;
 public class PlasmaShield extends AbstractUtilityCard {
     public static final String ID = SpireAnniversary5Mod.makeID("PlasmaShield");
     private static final int COST = 2;
-    private static final int AMOUNT = 3;
+    private static final int AMOUNT = 4;
     private static final int UPGRADE_AMOUNT = 2;
     private static final int PLASMA = 1;
 

--- a/src/main/java/thePackmaster/packs/AggressionPack.java
+++ b/src/main/java/thePackmaster/packs/AggressionPack.java
@@ -13,9 +13,10 @@ public class AggressionPack extends AbstractCardPack {
     public static final String NAME = UI_STRINGS.TEXT[0];
     public static final String DESC = UI_STRINGS.TEXT[1];
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
+    public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public AggressionPack() {
-        super(ID, NAME, DESC, AUTHOR);
+        super(ID, NAME, DESC, AUTHOR, CREDITS);
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/PrismaticPack.java
+++ b/src/main/java/thePackmaster/packs/PrismaticPack.java
@@ -13,9 +13,10 @@ public class PrismaticPack extends AbstractCardPack {
     public static final String NAME = UI_STRINGS.TEXT[0];
     public static final String DESC = UI_STRINGS.TEXT[1];
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
+    public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public PrismaticPack() {
-        super(ID, NAME, DESC, AUTHOR);
+        super(ID, NAME, DESC, AUTHOR, CREDITS);
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ShamanPack.java
+++ b/src/main/java/thePackmaster/packs/ShamanPack.java
@@ -13,9 +13,10 @@ public class ShamanPack extends AbstractCardPack {
     public static final String NAME = UI_STRINGS.TEXT[0];
     public static final String DESC = UI_STRINGS.TEXT[1];
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
+    public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public ShamanPack() {
-        super(ID, NAME, DESC, AUTHOR);
+        super(ID, NAME, DESC, AUTHOR, CREDITS);
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ShamanPack.java
+++ b/src/main/java/thePackmaster/packs/ShamanPack.java
@@ -32,6 +32,7 @@ public class ShamanPack extends AbstractCardPack {
         cards.add(Pyromastery.ID);
         cards.add(ReadTheFlames.ID);
         cards.add(FueledByEmbers.ID);
+        cards.add(FadingEmber.ID);
         return cards;
     }
 }

--- a/src/main/java/thePackmaster/packs/UtilityPack.java
+++ b/src/main/java/thePackmaster/packs/UtilityPack.java
@@ -30,6 +30,7 @@ public class UtilityPack extends AbstractCardPack {
         cards.add(Whispers.ID);
         cards.add(Replenish.ID);
         cards.add(LesserHex.ID);
+        cards.add(GreaterHex.ID);
         cards.add(Conjuration.ID);
         cards.add(RareStrike.ID);
         return cards;

--- a/src/main/java/thePackmaster/packs/UtilityPack.java
+++ b/src/main/java/thePackmaster/packs/UtilityPack.java
@@ -13,9 +13,10 @@ public class UtilityPack extends AbstractCardPack {
     public static final String NAME = UI_STRINGS.TEXT[0];
     public static final String DESC = UI_STRINGS.TEXT[1];
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
+    public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public UtilityPack() {
-        super(ID, NAME, DESC, AUTHOR);
+        super(ID, NAME, DESC, AUTHOR, CREDITS);
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/WarlockPack.java
+++ b/src/main/java/thePackmaster/packs/WarlockPack.java
@@ -13,9 +13,10 @@ public class WarlockPack extends AbstractCardPack {
     public static final String NAME = UI_STRINGS.TEXT[0];
     public static final String DESC = UI_STRINGS.TEXT[1];
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
+    public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public WarlockPack() {
-        super(ID, NAME, DESC, AUTHOR);
+        super(ID, NAME, DESC, AUTHOR, CREDITS);
     }
 
     @Override

--- a/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
+++ b/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
@@ -164,7 +164,7 @@ public class MainMenuUIPatch {
                 // If toggle button is checked, render the dropdowns, too
                 if (customDraft) {
                     for (int i = dropdowns.size() - 1; i >= 0; i--) {
-                        dropdowns.get(i).render(sb, DROPDOWN_X, DROPDOWNS_START_Y - (DROPDOWNS_SPACING * i)); //TODO: Place correctly
+                        dropdowns.get(i).render(sb, DROPDOWN_X, DROPDOWNS_START_Y - (DROPDOWNS_SPACING * i));
                     }
                 }
 

--- a/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
+++ b/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
@@ -91,7 +91,7 @@ public class MainMenuUIPatch {
         ) {
             if (Objects.equals(s, RANDOM) || Objects.equals(s, CHOICE)) {
                 packSetups.add(s);
-            } else if (SpireAnniversary5Mod.packsByID.get(s) != null) {
+            } else if (SpireAnniversary5Mod.packsByID.getOrDefault(s, null) != null) {
                 packSetups.add(s);
             } else {
                 packSetups.add(RANDOM); //This will only get hit if there is an invalid entry being loaded, such as Pack that no longer exists.  In that event, replace it with RANDOM.

--- a/src/main/java/thePackmaster/ui/PackFilterMenu.java
+++ b/src/main/java/thePackmaster/ui/PackFilterMenu.java
@@ -11,6 +11,7 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.FontHelper;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.helpers.TipHelper;
 import com.megacrit.cardcrawl.screens.options.DropdownMenu;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.packs.AbstractCardPack;
@@ -110,6 +111,14 @@ public class PackFilterMenu {
         previewCard.update();
         previewCard.current_x = PREVIEW_X;
         previewCard.current_y = PREVIEW_Y;
+        previewCard.hb.move(previewCard.current_x, previewCard.current_y);
+        previewCard.hb.update();
+        if (viewedPack.credits != null) {
+            TipHelper.renderGenericTip(
+                    previewCard.current_x + previewCard.hb.width,
+                    previewCard.current_y + previewCard.hb.height,
+                    viewedPack.creditsHeader, viewedPack.credits);
+        }
         FontHelper.cardTitleFont.getData().setScale(1f);
     }
 

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -49,7 +49,7 @@
     "DESCRIPTIONS": [
       "When acquired, choose 1 of 3 Packmaster Boosters, three times. Earn one additional card reward from these boosters at the end of each combat.",
       " NL Chosen Boosters: ",
-      "Chooose a Booster Pack."
+      "Choose a Booster Pack."
     ]
   },
   "${ModID}:PMBoosterPack": {

--- a/src/main/resources/anniv5Resources/localization/eng/aggressionpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/aggressionpack/Cardstrings.json
@@ -33,7 +33,7 @@
   },
   "${ModID}:LunaticRage": {
     "NAME": "Lunatic Rage",
-    "DESCRIPTION": "Draw !M! cards. NL Gain [E] [E] . NL Discard all non-Attack cards. NL Exhaust."
+    "DESCRIPTION": "Draw !M! cards. NL Gain [E] [E] . NL Discard all non-Attack non-Status cards. NL Exhaust."
   },
   "${ModID}:Animosity": {
     "NAME": "Animosity",

--- a/src/main/resources/anniv5Resources/localization/eng/aggressionpack/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/aggressionpack/UIstrings.json
@@ -3,7 +3,8 @@
     "TEXT": [
       "Aggression",
       "Focused on attacks and the Aggression stance, which increases your attack damage by 25%.",
-      "modargo"
+      "modargo",
+      "Card art from MtG"
     ]
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/prismaticpack/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/prismaticpack/UIstrings.json
@@ -3,7 +3,8 @@
     "TEXT": [
       "Prismatic",
       "Focused on making and benefiting from cards of different colors.",
-      "modargo"
+      "modargo",
+      "Card art from MtG"
     ]
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/shamanpack/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/shamanpack/UIstrings.json
@@ -3,7 +3,8 @@
     "TEXT": [
       "Shaman",
       "Cards from and inspired by the Shaman character mod.",
-      "modargo"
+      "modargo",
+      "Card art from MtG"
     ]
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/utilitypack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/utilitypack/Cardstrings.json
@@ -19,8 +19,7 @@
   },
   "${ModID}:Enrage": {
     "NAME": "Enrage",
-    "DESCRIPTION": "Discard !${ModID}:m2! cards. NL Draw !M! card. NL Enter ${ModID}:Aggression.",
-    "UPGRADE_DESCRIPTION": "Discard !${ModID}:m2! cards. NL Draw !M! cards. NL Enter ${ModID}:Aggression."
+    "DESCRIPTION": "Discard !${ModID}:m2! cards. NL Draw !M! cards. NL Enter ${ModID}:Aggression."
   },
   "${ModID}:Whispers": {
     "NAME": "Whispers",

--- a/src/main/resources/anniv5Resources/localization/eng/utilitypack/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/utilitypack/UIstrings.json
@@ -3,7 +3,8 @@
     "TEXT": [
       "Utility",
       "Cards that synergize well with a wide range of mechanics and packs.",
-      "modargo"
+      "modargo",
+      "Card art from MtG"
     ]
   },
   "${ModID}:ConjurationAction": {

--- a/src/main/resources/anniv5Resources/localization/eng/warlockpack/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/warlockpack/UIstrings.json
@@ -3,7 +3,8 @@
     "TEXT": [
       "Warlock",
       "Be a Warlock and channel\u00a0Fel energy, exhausting cards and creating imps to destroy your enemies.",
-      "Diamsword & modargo"
+      "Diamsword & modargo",
+      "#yHearthstone originally created by #yBlizzard #yEntertainment"
     ]
   }
 }


### PR DESCRIPTION
As usual, a collection of fixes and tweaks courtesy of my development and playtesting. I believe I could merge this myself, but I felt it was more appropriate to let you review my PRs instead, to keep you informed of changes if nothing else.

Thanks for pointing me to the additional credits field -- I was too caught up with streaming/playing to respond when you mentioned it, but I've gone through and filled it out for my packs. I must not have been paying attention when this field was added because I'd completely missed it.

I also added a tooltip with the additional credits to the pack filter menu. Felt to me like if it showed up on the pack setup screen, it should also show up during pack filtering. Plus that makes it easier to check since you don't need to start a run to see it. I thought about having it only show up on hover, but it looked nice enough that I made it show up whenever you have a pack with additional credits showing -- I'm pleased by the result.

Since I'm not using hover, the code I added for setting the hitbox location isn't strictly necessary, but I left it in because without the code, the hitbox is incorrectly positioned. Specifically, it looked like the hitbox was jittering, leading to tooltips that jumped around/appeared and disappeared. Better to have it set properly in case we want to add something else on hover.

Other than those changes, I made some balance tweaks to my packs, based on how things felt in my recent runs and what I saw/heard from a few other runs. I also did another sweep for cards that should be tagged as healing, specifically looking for cards that make potions and cards that have other permanent effects (I covered cards that heal or gain gold in my previous sweep).

![image](https://user-images.githubusercontent.com/62083413/212523693-7cd2d382-4624-444c-aa51-33cf6bf94e11.png)