### PR TITLE
Rework Bag of Holding and wording tweaks/fixes/flavor text for core relics

### DIFF
--- a/src/main/java/thePackmaster/relics/BagOfHolding.java
+++ b/src/main/java/thePackmaster/relics/BagOfHolding.java
@@ -1,49 +1,44 @@
 package thePackmaster.relics;
 
-import com.megacrit.cardcrawl.actions.common.GainBlockAction;
+import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import com.megacrit.cardcrawl.powers.BlurPower;
-import thePackmaster.ThePackmaster;
-import thePackmaster.util.Wiz;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public class BagOfHolding extends AbstractPackmasterRelic {
     public static final String ID = makeID("BagOfHolding");
 
-    private boolean firstTurn = true;
-
     public BagOfHolding() {
         super(ID, RelicTier.BOSS, LandingSound.FLAT);
     }
 
+    @Override
     public void atPreBattle() {
-        this.firstTurn = true;
+        this.counter = AbstractDungeon.player.masterDeck.size() / 5;
     }
 
+    @Override
     public void atTurnStart() {
-        int count = AbstractDungeon.player.masterDeck.size();
-        if (this.firstTurn) {
+        if (!this.grayscale) {
             flash();
-            if (count >= 10){
-                addToTop(new RelicAboveCreatureAction(AbstractDungeon.player, this));
-                addToTop(new com.megacrit.cardcrawl.actions.common.GainEnergyAction(1));
-            }
-            if (count >= 20){
-                addToTop(new com.megacrit.cardcrawl.actions.common.DrawCardAction(2));
-            }
-            this.firstTurn = false;
-        } else {
-            if (count >= 30){
-                addToTop(new RelicAboveCreatureAction(AbstractDungeon.player, this));
-                addToTop(new com.megacrit.cardcrawl.actions.common.GainEnergyAction(1));
-            }
-            if (count >= 40){
-                addToTop(new com.megacrit.cardcrawl.actions.common.DrawCardAction(2));
+            addToTop(new RelicAboveCreatureAction(AbstractDungeon.player, this));
+            addToTop(new GainEnergyAction(1));
+            this.counter--;
+
+            if (this.counter <= 0) {
+                this.counter = -1;
+                this.grayscale = true;
             }
         }
     }
+
+    @Override
+    public void onVictory() {
+        this.grayscale = false;
+        this.counter = -1;
+    }
+
     @Override
     public void obtain() {
         if (AbstractDungeon.player.hasRelic(HandyHaversack.ID)) {

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -32,7 +32,7 @@
     "NAME": "Gem of Unity",
     "FLAVOR": "In union there is strength.",
     "DESCRIPTIONS": [
-      "Once per combat, after you have played a card from each different Pack available this run, gain 20 Block, 1 Strength, 1 Dexterity, and heal 5 HP.",
+      "Once per combat, after you have played a card from each different Pack available this run, gain #b20 Block, #b1 Strength, #b1 Dexterity, and heal #b5 HP.",
       "Packs played this combat: "
     ]
   },

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -3,7 +3,7 @@
     "NAME": "Bag of Holding",
     "FLAVOR": "\"Incredible! It appears that this bag connects to an extradimensional space. What if I jump inside?\" - Ranwid",
     "DESCRIPTIONS": [
-      "At the start of each combat: NL Gain [E] if you have 10 or cards in your deck. This happens every turn if you have 30 or more. NL Draw 2 cards if you have 20 or more cards in your deck. This happens every turn if you have 40 or more."
+      "Gain [E] at the start of each turn, lasting one turn for every #b5 cards in your deck."
     ]
   },
   "${ModID}:BanishingDecree": {

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -47,7 +47,7 @@
     "NAME": "P.M. Booster Box",
     "FLAVOR": "Better price for buying in bulk.",
     "DESCRIPTIONS": [
-      "When acquired, choose 1 of 3 Packmaster Boosters, three times. Earn one additional card reward from these boosters at the end of each combat.",
+      "Upon pickup, choose 1 of 3 Packmaster Boosters, three times. Earn one additional card reward from these boosters at the end of each combat.",
       " NL Chosen Boosters: ",
       "Choose a Booster Pack."
     ]
@@ -56,7 +56,7 @@
     "NAME": "P.M. Booster Pack",
     "FLAVOR": "A package of cards in a foil wrapper. How did it end up in the Spire?",
     "DESCRIPTIONS": [
-      "When acquired, from a randomly chosen Packmaster Booster, you may add any one of its cards to your deck.",
+      "Upon pickup, from a randomly chosen Packmaster Booster, you may add any one of its cards to your deck.",
       "Choose a card to add to your deck."
     ]
   },
@@ -64,7 +64,7 @@
     "NAME": "P.M. Collection",
     "FLAVOR": "Said to have been assembled by a consortium of wizards.",
     "DESCRIPTIONS": [
-      "When acquired, from a randomly chosen Packmaster Booster, you may add each card from it to your deck.",
+      "Upon pickup, from a randomly chosen Packmaster Booster, you may add each card from it to your deck.",
       "You may add this to your deck."
     ]
   }

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -56,7 +56,7 @@
     "NAME": "P.M. Booster Pack",
     "FLAVOR": "A package of cards in a foil wrapper. How did it end up in the Spire?",
     "DESCRIPTIONS": [
-      "Upon pickup, from a randomly chosen Packmaster Booster, you may add any one of its cards to your deck.",
+      "Upon pickup, you may add any one card from a random Packmaster Booster to your deck.",
       "Choose a card to add to your deck."
     ]
   },
@@ -64,7 +64,7 @@
     "NAME": "P.M. Collection",
     "FLAVOR": "Said to have been assembled by a consortium of wizards.",
     "DESCRIPTIONS": [
-      "Upon pickup, from a randomly chosen Packmaster Booster, you may add each card from it to your deck.",
+      "Upon pickup, you may add each card from a random Packmaster Booster to your deck.",
       "You may add this to your deck."
     ]
   }

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -47,7 +47,7 @@
     "NAME": "P.M. Booster Box",
     "FLAVOR": "Better price for buying in bulk.",
     "DESCRIPTIONS": [
-      "Upon pickup, choose 1 of 3 Packmaster Boosters, three times. Earn one additional card reward from these boosters at the end of each combat.",
+      "Upon pickup, choose #b1 of #b3 Packmaster Boosters, three times. Earn one additional card reward from these boosters at the end of each combat.",
       " NL Chosen Boosters: ",
       "Choose a Booster Pack."
     ]

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -45,7 +45,7 @@
   },
   "${ModID}:PMBoosterBox": {
     "NAME": "P.M. Booster Box",
-    "FLAVOR": "TODO: make this a sweet relic.",
+    "FLAVOR": "Better price for buying in bulk.",
     "DESCRIPTIONS": [
       "When acquired, choose 1 of 3 Packmaster Boosters, three times. Earn one additional card reward from these boosters at the end of each combat.",
       " NL Chosen Boosters: ",
@@ -54,7 +54,7 @@
   },
   "${ModID}:PMBoosterPack": {
     "NAME": "P.M. Booster Pack",
-    "FLAVOR": "TODO: make this a sweet relic.",
+    "FLAVOR": "A package of cards in a foil wrapper. How did it end up in the Spire?",
     "DESCRIPTIONS": [
       "When acquired, from a randomly chosen Packmaster Booster, you may add any one of its cards to your deck.",
       "Choose a card to add to your deck."
@@ -62,7 +62,7 @@
   },
   "${ModID}:PMCollection": {
     "NAME": "P.M. Collection",
-    "FLAVOR": "TODO: make this a sweet relic.",
+    "FLAVOR": "Said to have been assembled by a consortium of wizards.",
     "DESCRIPTIONS": [
       "When acquired, from a randomly chosen Packmaster Booster, you may add each card from it to your deck.",
       "You may add this to your deck."


### PR DESCRIPTION
The Bag of Holding rework is as discussed.

The rest o the changes are me (1) continuing to add flavor text to relics and (2) noticing a variety of things that could be improved about the existing relic wording.

![image](https://user-images.githubusercontent.com/62083413/212548643-4515a91e-6de5-4e4f-9d63-176002088306.png)
