### PR TITLE
Backpack Smack rework, hat menu sorting fix, Conjuration bugfix

### DIFF
--- a/src/main/java/thePackmaster/cards/coresetpack/BackpackSmack.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/BackpackSmack.java
@@ -16,24 +16,23 @@ public class BackpackSmack extends AbstractPackmasterCard {
 
     public BackpackSmack() {
         super(ID, 1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
-        baseDamage = 5;
+        baseDamage = 7;
+        magicNumber = baseMagicNumber = 2;
 
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
         dmg(m, AbstractGameAction.AttackEffect.BLUNT_HEAVY);
-        if (p.drawPile.size() > 9) {
-            AbstractDungeon.actionManager.addToBottom(new DrawCardAction(p, 1));
+        if (p.drawPile.size() >= 10) {
+            AbstractDungeon.actionManager.addToBottom(new DrawCardAction(p, this.magicNumber));
+        }
+        else {
             AbstractDungeon.actionManager.addToBottom(new GainEnergyAction(1));
         }
     }
 
-    @Override
-    public void triggerOnGlowCheck() {
-        glowColor = AbstractDungeon.player.drawPile.size() > 9 ? GOLD_BORDER_GLOW_COLOR : BLUE_BORDER_GLOW_COLOR;
-    }
-
     public void upp() {
-        upgradeDamage(3);
+        upgradeDamage(2);
+        upgradeMagicNumber(1);
     }
 }

--- a/src/main/java/thePackmaster/hats/HatMenu.java
+++ b/src/main/java/thePackmaster/hats/HatMenu.java
@@ -16,6 +16,7 @@ import thePackmaster.ThePackmaster;
 import thePackmaster.packs.AbstractCardPack;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 
 import static thePackmaster.hats.Hats.currentHat;
 
@@ -78,7 +79,9 @@ public class HatMenu {
 
         ArrayList<String> optionNames = new ArrayList<>();
         optionNames.add(TEXT[0]);
-        for (AbstractCardPack s : SpireAnniversary5Mod.unfilteredAllPacks) {
+        ArrayList<AbstractCardPack> sortedPacks = new ArrayList<>(SpireAnniversary5Mod.unfilteredAllPacks);
+        sortedPacks.sort(Comparator.comparing((pack) -> pack.name));
+        for (AbstractCardPack s : sortedPacks) {
             if (Gdx.files.internal(Hats.getImagePathFromHatID(s.packID)).exists()) {
                 if (unlockedHats.contains(s.packID)) SpireAnniversary5Mod.logger.info("Hat unlock exists: " + s.packID);
                 if (UNLOCK_ALL_HATS) SpireAnniversary5Mod.logger.info("Unlock All Hats enabled and is unlocking " + s.packID);

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
@@ -1,7 +1,7 @@
 {
   "${ModID}:BackpackSmack": {
     "NAME": "Backpack Smack",
-    "DESCRIPTION": "Deal !D! damage. NL If your draw pile contains 10 or more cards, gain [E] and draw a card."
+    "DESCRIPTION": "Deal !D! damage. NL If your draw pile has 10 or more cards, draw !M! cards. NL Otherwise, gain [E] ."
   },
   "${ModID}:BoosterTutor": {
     "NAME": "Booster Tutor",

--- a/src/main/resources/anniv5Resources/localization/eng/utilitypack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/utilitypack/Cardstrings.json
@@ -42,7 +42,8 @@
   "${ModID}:Conjuration": {
     "NAME": "Conjuration",
     "DESCRIPTION": "Choose a card from your draw pile. NL Play and Exhaust it.",
-    "UPGRADE_DESCRIPTION": "Choose a card from your draw pile. NL Play it."
+    "UPGRADE_DESCRIPTION": "Choose a card from your draw pile. NL Play it.",
+    "EXTENDED_DESCRIPTION": ["There are no cards in my draw pile."]
   },
   "${ModID}:RareStrike": {
     "NAME": "Rare Strike",


### PR DESCRIPTION
You logged off for the night just as I was typing up another message about fixing Backpack Smack -- we had a good discussion of it (see https://discord.com/channels/309399445785673728/398373038732738570/1064310635250335744 if you're interested) and I ended up implementing a variant of the design discussed. After the discussion I wasn't in a rush to merge it, so I've left this PR for you to see.

Specifically, I decided that making the card give two energy when upgraded was just too much (I couldn't stomach the idea of going infinite with just an upgraded Backpack Smack plus Shrug It Off), so I shifted some power to the draw (which is the harder trigger to hit in the early game, and still not very consistent later game, at least not until you get to 30+ cards).

Here's the result (the upgrade increases damage by 2 and draw by 1. Maybe it's too much, but I wanted to get something in for testing and the conditionality of this made me think it would be strong but not too strong.
![image](https://user-images.githubusercontent.com/62083413/212587758-ddfd0990-7e51-4f8a-86f4-eaaecdba0b22.png)

The other change in this PR are applying the same name sorting logic to the new hats menu and fixing a missing extended description entry for one of the cards in the Utility pack.