### PR TITLE
Fix positions for the hat menu and pack filtering menu

### DIFF
--- a/src/main/java/thePackmaster/hats/HatMenu.java
+++ b/src/main/java/thePackmaster/hats/HatMenu.java
@@ -50,12 +50,12 @@ public class HatMenu {
     //positions
     private static final float BG_X_SCALE = Settings.scale * 0.275f;
     private static final float BG_Y_SCALE = Settings.scale * 0.8f;
-    private static final float BG_X = 525f * Settings.xScale;
-    private static final float BG_Y = Settings.HEIGHT - 40f * Settings.yScale - MENU_BG.getRegionHeight() * BG_Y_SCALE;
-    private static final float DROPDOWN_X = 550f * Settings.xScale;
-    private static final float DROPDOWN_Y = Settings.HEIGHT - 160f * Settings.yScale;
+    private static final float BG_X = 525f * Settings.scale;
+    private static final float BG_Y = Settings.HEIGHT - 40f * Settings.scale - MENU_BG.getRegionHeight() * BG_Y_SCALE;
+    private static final float DROPDOWN_X = 559f * Settings.scale;
+    private static final float DROPDOWN_Y = Settings.HEIGHT - 160f * Settings.scale;
     private static final float PREVIEW_X = BG_X + (210 * Settings.scale);
-    private static final float PREVIEW_Y = BG_Y + (225 * Settings.scale);
+    private static final float PREVIEW_Y = BG_Y + (215 * Settings.scale);
 
     public static AbstractPlayer dummy;
 

--- a/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
+++ b/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
@@ -53,7 +53,7 @@ public class MainMenuUIPatch {
     private static final float DROPDOWNS_START_Y = CHECKBOX_Y + DROPDOWNS_SPACING * (PACK_COUNT + 0.5f);
 
     //filter button fields
-    private static final float FILTERBUTTON_X = 60f;
+    private static final float FILTERBUTTON_X = 55f;
     private static final float FILTERBUTTON_Y = 1080f - 122f;
 
     private static final PackFilterMenu filterMenu = new PackFilterMenu();
@@ -61,7 +61,7 @@ public class MainMenuUIPatch {
     private static final HashMap<String, Integer> idToIndex = new HashMap<>();
 
     //hat button fields
-    private static final float HATBUTTON_X = 560f;
+    private static final float HATBUTTON_X = 610f;
     private static final float HATBUTTON_Y = 1080f - 122f;
 
     public static final HatMenu hatMenu = new HatMenu();

--- a/src/main/java/thePackmaster/ui/PackFilterMenu.java
+++ b/src/main/java/thePackmaster/ui/PackFilterMenu.java
@@ -37,14 +37,14 @@ public class PackFilterMenu {
     //positions
     private static final float BG_X_SCALE = Settings.scale * 0.31f;
     private static final float BG_Y_SCALE = Settings.scale * 0.8f;
-    private static final float BG_X = 25f * Settings.xScale;
-    private static final float BG_Y = Settings.HEIGHT - 40f * Settings.yScale - MENU_BG.getRegionHeight() * BG_Y_SCALE;
-    private static final float DROPDOWN_X = 90f * Settings.xScale;
-    private static final float DROPDOWN_Y = Settings.HEIGHT - 160f * Settings.yScale;
+    private static final float BG_X = 25f * Settings.scale;
+    private static final float BG_Y = Settings.HEIGHT - 40f * Settings.scale - MENU_BG.getRegionHeight() * BG_Y_SCALE;
+    private static final float DROPDOWN_X = 90f * Settings.scale;
+    private static final float DROPDOWN_Y = Settings.HEIGHT - 160f * Settings.scale;
     private static final float CHECKBOX_X = 150f;
     private static final float CHECKBOX_Y = 490f;
-    private static final float PREVIEW_X = 235f * Settings.xScale;
-    private static final float PREVIEW_Y = 700f * Settings.yScale;
+    private static final float PREVIEW_X = 235f * Settings.scale;
+    private static final float PREVIEW_Y = 700f * Settings.scale;
 
     public PackFilterMenu() {
         SpireAnniversary5Mod.logger.info("Settings.HEIGHT = " + Settings.HEIGHT);


### PR DESCRIPTION
Tweaked positioning, tested with other resolutions, and also works properly in wide resolutions

Before : 

![Before](https://user-images.githubusercontent.com/104149087/213390457-0a926f3a-c043-46b5-beb4-c130d44f4dcb.png)

After : 

![After](https://user-images.githubusercontent.com/104149087/213390475-308dcf15-6d24-4107-889c-0a4b868f64be.png)
