### PR TITLE
Core set relics: fix PM Booster Box to properly save/load and fix both it and Banishing Decree to use seeded RNG and respect relics like Question Card and Busted Crown for their rewards

### DIFF
--- a/src/main/java/thePackmaster/SpireAnniversary5Mod.java
+++ b/src/main/java/thePackmaster/SpireAnniversary5Mod.java
@@ -31,20 +31,18 @@ import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import com.megacrit.cardcrawl.events.city.BackToBasics;
 import com.megacrit.cardcrawl.helpers.CardHelper;
 import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.helpers.FontHelper;
 import com.megacrit.cardcrawl.localization.*;
-import com.megacrit.cardcrawl.orbs.*;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.powers.ArtifactPower;
 import com.megacrit.cardcrawl.powers.watcher.VigorPower;
 import com.megacrit.cardcrawl.random.Random;
+import com.megacrit.cardcrawl.rewards.RewardSave;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.stances.AbstractStance;
 import com.megacrit.cardcrawl.stances.CalmStance;
-import com.megacrit.cardcrawl.stances.NeutralStance;
 import com.megacrit.cardcrawl.unlock.UnlockTracker;
 import javassist.CtClass;
 import org.apache.logging.log4j.LogManager;
@@ -59,14 +57,9 @@ import thePackmaster.cards.ringofpainpack.Slime;
 import thePackmaster.events.BlackMarketDealerEvent;
 import thePackmaster.hats.HatMenu;
 import thePackmaster.hats.Hats;
-import thePackmaster.orbs.WitchesStrike.CrescentMoon;
-import thePackmaster.orbs.WitchesStrike.FullMoon;
-import thePackmaster.orbs.downfallpack.Ghostflame;
-import thePackmaster.orbs.entropy.Oblivion;
 import thePackmaster.orbs.summonspack.Leprechaun;
 import thePackmaster.orbs.summonspack.Louse;
 import thePackmaster.orbs.summonspack.Panda;
-import thePackmaster.orbs.summonspack.SwarmOfBees;
 import thePackmaster.packs.*;
 import thePackmaster.patches.MainMenuUIPatch;
 import thePackmaster.patches.contentcreatorpack.DisableCountingStartOfTurnDrawPatch;
@@ -88,6 +81,8 @@ import thePackmaster.powers.bitingcoldpack.GlaciatePower;
 import thePackmaster.powers.dragonwrathpack.PenancePower;
 import thePackmaster.powers.thieverypack.MindControlledPower;
 import thePackmaster.relics.AbstractPackmasterRelic;
+import thePackmaster.rewards.CustomRewardTypes;
+import thePackmaster.rewards.PMBoosterBoxCardReward;
 import thePackmaster.screens.PackSetupScreen;
 import thePackmaster.stances.aggressionpack.AggressionStance;
 import thePackmaster.stances.cthulhupack.NightmareStance;
@@ -98,7 +93,6 @@ import thePackmaster.ui.CurrentRunCardsTopPanelItem;
 import thePackmaster.ui.InfestTextIcon;
 import thePackmaster.ui.PackFilterMenu;
 import thePackmaster.util.TexLoader;
-import thePackmaster.util.Wiz;
 import thePackmaster.util.cardvars.HoardVar;
 import thePackmaster.vfx.distortionpack.ImproveEffect;
 
@@ -443,6 +437,8 @@ public class SpireAnniversary5Mod implements
 
         addPotions();
 
+        registerCustomRewards();
+
         initializeConfig();
 
         initializeSavedData();
@@ -707,24 +703,22 @@ public class SpireAnniversary5Mod implements
         return validCards.get(AbstractDungeon.cardRandomRng.random(0, validCards.size() - 1)).makeCopy();
     }
 
-
-    public static ArrayList<AbstractCard> getCardsFromPacks(String pack, int count) {
+    public static ArrayList<AbstractCard> getCardsFromPacks(String pack, int count, Random rng) {
         ArrayList<String> quick = new ArrayList<>();
         quick.add(pack);
-        return getCardsFromPacks(quick, count);
+        return getCardsFromPacks(quick, count, rng);
     }
 
-    public static ArrayList<AbstractCard> getCardsFromPacks(ArrayList<String> packs, int count) {
+    public static ArrayList<AbstractCard> getCardsFromPacks(ArrayList<String> packs, int count, Random rng) {
         ArrayList<AbstractCard> cards = new ArrayList<>();
-        for (String s : packs
-        ) {
+        for (String s : packs) {
             AbstractCardPack p = packsByID.get(s);
-            for (String s2 : p.getCards()
-            ) {
+            for (String s2 : p.getCards()) {
                 if (CardLibrary.getCard(s2).rarity == AbstractCard.CardRarity.COMMON ||
                         CardLibrary.getCard(s2).rarity == AbstractCard.CardRarity.UNCOMMON ||
-                        CardLibrary.getCard(s2).rarity == AbstractCard.CardRarity.RARE)
+                        CardLibrary.getCard(s2).rarity == AbstractCard.CardRarity.RARE) {
                     cards.add(CardLibrary.getCard(s2).makeCopy());
+                }
             }
         }
 
@@ -734,7 +728,7 @@ public class SpireAnniversary5Mod implements
         }
 
         //Otherwise make a new list with random N cards from the original list and return that
-        Collections.shuffle(cards);
+        Collections.shuffle(cards, new java.util.Random(rng.randomLong()));
         ArrayList<AbstractCard> cards2 = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             cards2.add(cards.get(i));
@@ -775,6 +769,13 @@ public class SpireAnniversary5Mod implements
             allChoices.remove(p);
         }
         return valid;
+    }
+
+    private void registerCustomRewards() {
+        BaseMod.registerCustomReward(
+                CustomRewardTypes.PACKMASTER_PMBOOSTERBOXCARD,
+                (rewardSave) -> new PMBoosterBoxCardReward(),
+                (customReward) -> new RewardSave(customReward.type.toString(), null, 0, 0));
     }
 
     public static void startOfGamePackSetup() {

--- a/src/main/java/thePackmaster/patches/PMBoosterBoxPatch.java
+++ b/src/main/java/thePackmaster/patches/PMBoosterBoxPatch.java
@@ -1,0 +1,52 @@
+package thePackmaster.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.rewards.RewardItem;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
+import com.megacrit.cardcrawl.screens.CombatRewardScreen;
+import com.megacrit.cardcrawl.ui.buttons.ProceedButton;
+import javassist.CtBehavior;
+import thePackmaster.relics.PMBoosterBox;
+import thePackmaster.rewards.PMBoosterBoxCardReward;
+
+public class PMBoosterBoxPatch {
+    @SpirePatch(clz = AbstractRoom.class, method = "update")
+    public static class AddRewardPatch {
+        @SpireInsertPatch(locator = Locator.class)
+        public static void addRewards(AbstractRoom __instance) {
+            if (AbstractDungeon.player.hasRelic(PMBoosterBox.ID)) {
+                AbstractDungeon.getCurrRoom().rewards.add(new PMBoosterBoxCardReward());
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(AbstractRoom.class, "addPotionToRewards");
+                return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
+            }
+        }
+    }
+
+    @SpirePatch(clz = CombatRewardScreen.class, method = "setupItemReward")
+    public static class PopulateCardsPatch {
+        @SpireInsertPatch(locator = Locator.class)
+        public static void populateCards(CombatRewardScreen __instance) {
+            for (RewardItem rewardItem : __instance.rewards) {
+                if (rewardItem instanceof PMBoosterBoxCardReward) {
+                    PMBoosterBoxCardReward reward = (PMBoosterBoxCardReward)rewardItem;
+                    reward.populateCards();
+                }
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(ProceedButton.class, "show");
+                return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
+            }
+        }
+    }
+}

--- a/src/main/java/thePackmaster/relics/BanishingDecree.java
+++ b/src/main/java/thePackmaster/relics/BanishingDecree.java
@@ -9,6 +9,7 @@ import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.PowerTip;
 import com.megacrit.cardcrawl.random.Random;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.rewards.RewardItem;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.rooms.ShopRoom;
@@ -118,9 +119,14 @@ public class BanishingDecree extends AbstractPackmasterRelic implements CustomSa
                 }
 
                 for (int i = 0; i < 3; i++) {
-                    RewardItem r = new RewardItem();
-                    r.cards = getCardsFromPacks(cp.packID, 3);
-                    AbstractDungeon.getCurrRoom().rewards.add(r);
+                    RewardItem reward = new RewardItem();
+                    reward.cards = getCardsFromPacks(cp.packID, reward.cards.size(), AbstractDungeon.cardRng);
+                    for (AbstractRelic relic : AbstractDungeon.player.relics) {
+                        for (AbstractCard c : reward.cards) {
+                            relic.onPreviewObtainCard(c);
+                        }
+                    }
+                    AbstractDungeon.getCurrRoom().rewards.add(reward);
                 }
 
                 skipDefaultCardRewards = true;

--- a/src/main/java/thePackmaster/relics/PMBoosterBox.java
+++ b/src/main/java/thePackmaster/relics/PMBoosterBox.java
@@ -26,18 +26,11 @@ public class PMBoosterBox extends AbstractPackmasterRelic implements CustomSavab
     private String myPackOne = "";
     private String myPackTwo = "";
     private String myPackThree = "";
-    private ArrayList<String> myPacks = new ArrayList<>();
+    public ArrayList<String> myPacks = new ArrayList<>();
 
 
     public PMBoosterBox() {
         super(ID, RelicTier.RARE, LandingSound.FLAT, null, true);
-    }
-
-    public void onVictory() {
-        //TODO - Known issue: if you exit the run during a reward screen, you lose this reward on load.
-        RewardItem r = new RewardItem();
-        r.cards = getCardsFromPacks(myPacks, 3);
-        AbstractDungeon.getCurrRoom().rewards.add(r);
     }
 
     @Override

--- a/src/main/java/thePackmaster/rewards/CustomRewardTypes.java
+++ b/src/main/java/thePackmaster/rewards/CustomRewardTypes.java
@@ -1,0 +1,9 @@
+package thePackmaster.rewards;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireEnum;
+import com.megacrit.cardcrawl.rewards.RewardItem;
+
+public class CustomRewardTypes {
+    @SpireEnum
+    public static RewardItem.RewardType PACKMASTER_PMBOOSTERBOXCARD;
+}

--- a/src/main/java/thePackmaster/rewards/PMBoosterBoxCardReward.java
+++ b/src/main/java/thePackmaster/rewards/PMBoosterBoxCardReward.java
@@ -1,0 +1,53 @@
+package thePackmaster.rewards;
+
+import basemod.abstracts.CustomReward;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.rewards.RewardItem;
+import thePackmaster.SpireAnniversary5Mod;
+import thePackmaster.relics.PMBoosterBox;
+
+import java.util.ArrayList;
+
+public class PMBoosterBoxCardReward extends CustomReward {
+    private static final String[] TEXT = CardCrawlGame.languagePack.getUIString(SpireAnniversary5Mod.makeID("PMBoosterBoxCardReward")).TEXT;
+
+    private ArrayList<AbstractCard> cards;
+
+    public PMBoosterBoxCardReward() {
+        super(ImageMaster.REWARD_CARD_NORMAL, TEXT[0], CustomRewardTypes.PACKMASTER_PMBOOSTERBOXCARD);
+    }
+
+    @Override
+    public boolean claimReward() {
+        if (AbstractDungeon.screen == AbstractDungeon.CurrentScreen.COMBAT_REWARD) {
+            AbstractDungeon.cardRewardScreen.open(this.cards, this, TEXT[1]);
+            AbstractDungeon.previousScreen = AbstractDungeon.CurrentScreen.COMBAT_REWARD;
+        }
+        return false;
+    }
+
+    public void populateCards() {
+        //We have this as a method that gets a delayed call (from a patch on CombatRewardScreen.open) because
+        //immediately generating the cards in the constructor would make saving and loading after combat change
+        //the cards you get (because we'd advance RNG the first time, save the advanced RNG, load, and generate
+        //card rewards from the advanced RNG)
+        if (this.cards == null) {
+            AbstractRelic boosterBox = AbstractDungeon.player.getRelic(PMBoosterBox.ID);
+            if (boosterBox != null) {
+                RewardItem reward = new RewardItem();
+                ArrayList<String> packs = ((PMBoosterBox)boosterBox).myPacks;
+                int numCards = reward.cards.size();
+                this.cards = SpireAnniversary5Mod.getCardsFromPacks(packs, numCards, AbstractDungeon.cardRng);
+                for (AbstractRelic relic : AbstractDungeon.player.relics) {
+                    for (AbstractCard c : this.cards) {
+                        relic.onPreviewObtainCard(c);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/anniv5Resources/localization/eng/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/UIstrings.json
@@ -134,5 +134,11 @@
       "One Frame For All. All Pack cards have normal Packmaster frames (Requires Restart).",
       "Share Content. Some Relics/ Potions can appear on other characters (Requires Restart)."
     ]
+  },
+  "${ModID}:PMBoosterBoxCardReward": {
+    "TEXT": [
+      "Add a booster box card",
+      "Choose a booster box card"
+    ]
   }
 }


### PR DESCRIPTION
The core idea of this implementation is that the way to properly save and load a card reward that has custom logic is to use a custom reward. Shouldn't be too surprising, but the tricky part is properly implementing custom rewards that generate cards and don't do weird things with RNG requires extra work.

That's because rewards are added right before the end-of-combat autosave, so any RNG calls advance the RNG to a new state that is then saved. If you save/reload, the reward is recreated, and it will advance RNG again. This solution avoids that by only generating the cards in the reward after the end-of-combat autosave -- this actually follows what the base game does with card rewards (the reward is only generated when you open the rewards screen).

There are definitely other ways to do this, but as far as I'm aware you have to do something along these lines to avoid RNG instability on save/load. This particular solution is based on what I did for Corrupt the Spire, so the core idea has been heavily tested and it's just the specific adaptation here that might introduce issues. See the following files for a sampling of the Corrupt the Spire implementation:
* https://github.com/modargo/corruptthespire/blob/f47f2a7b9ee5950e128d01960d519c6ed949fb7d/src/main/java/corruptthespire/rewards/CorruptedCardReward.java
* https://github.com/modargo/corruptthespire/blob/f47f2a7b9ee5950e128d01960d519c6ed949fb7d/src/main/java/corruptthespire/patches/fight/FightCorruptionAddRewardsPatch.java
* https://github.com/modargo/corruptthespire/blob/f47f2a7b9ee5950e128d01960d519c6ed949fb7d/src/main/java/corruptthespire/patches/rewards/PopulateCardsForCorruptedCardRewardPatch.java