### PR TITLE
Make Gem of Unity flash so I would be confused no more.

### DIFF
--- a/src/main/java/thePackmaster/relics/GemOfUnity.java
+++ b/src/main/java/thePackmaster/relics/GemOfUnity.java
@@ -52,6 +52,7 @@ public class GemOfUnity extends AbstractPackmasterRelic {
             counter--;
             packsPlayed.add(pack);
             if (counter == 0){
+                flash();
                 AbstractDungeon.player.heal(5);
                 addToBot(new GainBlockAction(Wiz.p(), 20));
                 Wiz.applyToSelf(new StrengthPower(Wiz.p(), 1));


### PR DESCRIPTION
While I was playing this mod, I repeatedly got 20 Block for seemingly no reason. Then I realized that it was Gem of Unity doing its thing. This PR changes Gem of Unity to show more of its presence.