### PR TITLE
Thievery Pack Changes 2

### DIFF
--- a/src/main/java/thePackmaster/actions/thieverypack/StealPowerAction.java
+++ b/src/main/java/thePackmaster/actions/thieverypack/StealPowerAction.java
@@ -50,7 +50,6 @@ public class StealPowerAction extends AbstractGameAction {
 	public static StealPowerAction activatedInstance = null;
 
 	public static boolean didMiss;
-	public static boolean canGoNegative;
 
 	/**
 	 * StealPowerAction can steal specified powers from enemies.
@@ -65,7 +64,6 @@ public class StealPowerAction extends AbstractGameAction {
 		this.monsters = monsters;
 		this.powIDAmountMap = powIDAmountMap;
 		this.animationMode = animationMode;
-		canGoNegative = false;
 	}
 
 	// for Null Hammer
@@ -75,7 +73,6 @@ public class StealPowerAction extends AbstractGameAction {
 				add(m);
 			}
 		}}, powIDAmountMap, animationMode);
-		canGoNegative = true;
 	}
 
 	// for Magnet (unupgraded)
@@ -163,7 +160,7 @@ public class StealPowerAction extends AbstractGameAction {
 			affectedPowers = new HashSet<>();
 			for (AbstractMonster m : monsters) {
 				for (AbstractPower pow : m.powers) {
-					if (powIDAmountMap.containsKey(pow.ID) && (canGoNegative || pow.amount > 0)) {
+					if (powIDAmountMap.containsKey(pow.ID) && (!pow.canGoNegative || pow.amount > 0)) {
 						affectedPowers.add(pow);
 					}
 				}
@@ -205,8 +202,6 @@ public class StealPowerAction extends AbstractGameAction {
 				int stealAmount;
 				if (mapAmount <= 0) {
 					stealAmount = pow.amount;
-				} else if (canGoNegative) {
-					stealAmount = mapAmount;
 				} else {
 					stealAmount = Math.min(pow.amount, mapAmount);
 				}
@@ -226,7 +221,7 @@ public class StealPowerAction extends AbstractGameAction {
 				}
 
 				// Enemy loses power
-				if (stealAmount == pow.amount || stealAmount > pow.amount && !canGoNegative) {
+				if (stealAmount >= pow.amount) {
 					addToTop(new RemoveSpecificPowerAction(pow.owner, p, pow) {
 						@Override
 						public void update() {
@@ -235,11 +230,10 @@ public class StealPowerAction extends AbstractGameAction {
 						}
 					});
 				} else {
-					int finalStealAmount = stealAmount;
 					addToTop(new AbstractGameAction() {
 						@Override
 						public void update() {
-							pow.amount -= finalStealAmount;
+							pow.amount -= stealAmount;
 							affectedPowers.remove(pow);
 							isDone = true;
 						}

--- a/src/main/java/thePackmaster/actions/thieverypack/WitchcraftAction.java
+++ b/src/main/java/thePackmaster/actions/thieverypack/WitchcraftAction.java
@@ -2,13 +2,14 @@ package thePackmaster.actions.thieverypack;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.HealAction;
-import com.megacrit.cardcrawl.actions.common.ObtainPotionAction;
 import com.megacrit.cardcrawl.actions.utility.WaitAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.powers.MinionPower;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.relics.Sozu;
 import com.megacrit.cardcrawl.vfx.combat.FlashAtkImgEffect;
 import thePackmaster.potions.thieverypack.DivinePotion;
 import thePackmaster.powers.thieverypack.ThieveryMasteryPower;
@@ -40,7 +41,12 @@ public class WitchcraftAction extends AbstractGameAction {
 				addToTop(new WaitAction(0.1F));
 			}
 			if ((target.isDying || target.currentHealth <= 0) && !target.halfDead && !target.hasPower(MinionPower.POWER_ID)) {
-				addToBot(new ObtainPotionAction(new DivinePotion()));
+				AbstractRelic s = AbstractDungeon.player.getRelic(Sozu.ID);
+				if (s != null) {
+					s.flash();
+				} else {
+					AbstractDungeon.player.obtainPotion(new DivinePotion());
+				}
 			}
 
 			if (AbstractDungeon.getCurrRoom().monsters.areMonstersBasicallyDead()) {

--- a/src/main/java/thePackmaster/cards/thieverypack/AbstractThieveryCard.java
+++ b/src/main/java/thePackmaster/cards/thieverypack/AbstractThieveryCard.java
@@ -4,7 +4,7 @@ import thePackmaster.cards.AbstractPackmasterCard;
 
 public abstract class AbstractThieveryCard extends AbstractPackmasterCard {
 	public AbstractThieveryCard(String ID, int cost, CardType type, CardRarity rarity, CardTarget target) {
-		super(ID, cost, type, rarity, target,"thieverypack");
+		super(ID, cost, type, rarity, target, "thieverypack");
 
 	}
 

--- a/src/main/java/thePackmaster/cards/thieverypack/FairTrade.java
+++ b/src/main/java/thePackmaster/cards/thieverypack/FairTrade.java
@@ -18,7 +18,7 @@ public class FairTrade extends AbstractThieveryCard {
 	private static final AbstractCard.CardRarity RARITY = CardRarity.COMMON;
 	private static final AbstractCard.CardTarget TARGET = CardTarget.ENEMY;
 
-	private static final int POWER = 5;
+	private static final int POWER = 6;
 	private static final int UPGRADE_BONUS = 2;
 	private static final int STRENGTH = 1;
 

--- a/src/main/java/thePackmaster/cards/thieverypack/Magnet.java
+++ b/src/main/java/thePackmaster/cards/thieverypack/Magnet.java
@@ -1,7 +1,5 @@
 package thePackmaster.cards.thieverypack;
 
-import com.megacrit.cardcrawl.actions.AbstractGameAction;
-import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -18,7 +16,7 @@ import java.util.ArrayList;
 public class Magnet extends AbstractThieveryCard {
 	public static final String RAW_ID = "Magnet";
 	public static final String ID = SpireAnniversary5Mod.makeID(RAW_ID);
-	private static final int COST = 1;
+	private static final int COST = 0;
 	private static final AbstractCard.CardType TYPE = CardType.SKILL;
 	private static final AbstractCard.CardRarity RARITY = CardRarity.UNCOMMON;
 	private static final AbstractCard.CardTarget TARGET = CardTarget.ENEMY;

--- a/src/main/java/thePackmaster/cards/thieverypack/NullHammer.java
+++ b/src/main/java/thePackmaster/cards/thieverypack/NullHammer.java
@@ -8,7 +8,6 @@ import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePackmaster.SpireAnniversary5Mod;
-import thePackmaster.powers.thieverypack.DeceivedPower;
 import thePackmaster.powers.thieverypack.HammeredPower;
 
 public class NullHammer extends AbstractThieveryCard {

--- a/src/main/java/thePackmaster/cards/thieverypack/StrengthSap.java
+++ b/src/main/java/thePackmaster/cards/thieverypack/StrengthSap.java
@@ -1,5 +1,6 @@
 package thePackmaster.cards.thieverypack;
 
+import com.evacipated.cardcrawl.mod.stslib.variables.ExhaustiveVariable;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
@@ -19,15 +20,18 @@ public class StrengthSap extends AbstractThieveryCard {
 	private static final AbstractCard.CardRarity RARITY = CardRarity.UNCOMMON;
 	private static final AbstractCard.CardTarget TARGET = CardTarget.ENEMY;
 
-	private static final int POWER = 1;
-	private static final int UPGRADE_BONUS = 1;
-	private static final int SECOND_POWER = 1;
-	private static final int UPGRADE_SECOND = 1;
+	private static final int WEAK = 1;
+	private static final int UPGRADE_WEAK = 1;
+	private static final int STEAL_STRENGTH = 1;
+	private static final int EXHAUSTIVE = 2;
+	private static final int UPGRADE_EXHAUSTIVE = 1;
 
 	public StrengthSap() {
 		super(ID, COST, TYPE, RARITY, TARGET);
-		baseMagicNumber = magicNumber = POWER;
-		baseSecondMagic = secondMagic = SECOND_POWER;
+		baseMagicNumber = magicNumber = WEAK;
+		baseSecondMagic = secondMagic = STEAL_STRENGTH;
+
+		ExhaustiveVariable.setBaseValue(this, EXHAUSTIVE);
 	}
 
 	@Override
@@ -54,8 +58,8 @@ public class StrengthSap extends AbstractThieveryCard {
 	public void upgrade() {
 		if (!upgraded) {
 			upgradeName();
-			upgradeMagicNumber(UPGRADE_BONUS);
-			upgradeSecondMagic(UPGRADE_SECOND);
+			upgradeMagicNumber(UPGRADE_WEAK);
+			ExhaustiveVariable.upgrade(this, UPGRADE_EXHAUSTIVE);
 		}
 	}
 }

--- a/src/main/java/thePackmaster/patches/thieverypack/MindControlPatch.java
+++ b/src/main/java/thePackmaster/patches/thieverypack/MindControlPatch.java
@@ -108,9 +108,13 @@ public class MindControlPatch {
 	@SpirePatch2(clz = MonsterGroup.class, method = "applyPreTurnLogic")
 	@SpirePatch2(clz = MonsterGroup.class, method = "applyEndOfTurnPowers")
 	public static class SuicidePatch {
+		public static boolean enabled = true;
+
 		@SpirePostfixPatch
 		public static void Postfix() {
-			MindControlledPower.checkForCombatEnd();
+			if (enabled) {
+				MindControlledPower.checkForCombatEnd();
+			}
 		}
 	}
 }

--- a/src/main/java/thePackmaster/powers/thieverypack/DeceivedPower.java
+++ b/src/main/java/thePackmaster/powers/thieverypack/DeceivedPower.java
@@ -1,8 +1,6 @@
 package thePackmaster.powers.thieverypack;
 
 import com.evacipated.cardcrawl.mod.stslib.patches.NeutralPowertypePatch;
-import com.evacipated.cardcrawl.mod.stslib.powers.interfaces.OnReceivePowerPower;
-import com.megacrit.cardcrawl.actions.common.DrawCardAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -13,8 +11,6 @@ import com.megacrit.cardcrawl.powers.PoisonPower;
 import com.megacrit.cardcrawl.vfx.GainPennyEffect;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.powers.AbstractPackmasterPower;
-
-import java.util.Dictionary;
 
 public class DeceivedPower extends AbstractPackmasterPower {
 	public static final String RAW_ID = "DeceivedPower";

--- a/src/main/java/thePackmaster/powers/thieverypack/HammeredPower.java
+++ b/src/main/java/thePackmaster/powers/thieverypack/HammeredPower.java
@@ -3,13 +3,13 @@ package thePackmaster.powers.thieverypack;
 import com.evacipated.cardcrawl.mod.stslib.patches.NeutralPowertypePatch;
 import com.evacipated.cardcrawl.mod.stslib.powers.interfaces.OnReceivePowerPower;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
-import com.megacrit.cardcrawl.actions.common.ReducePowerAction;
 import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.localization.PowerStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.powers.BackAttackPower;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.actions.thieverypack.StealPowerAction;
 import thePackmaster.powers.AbstractPackmasterPower;
@@ -44,7 +44,7 @@ public class HammeredPower extends AbstractPackmasterPower implements OnReceiveP
 
 	@Override
 	public boolean onReceivePower(AbstractPower power, AbstractCreature target, AbstractCreature source) {
-		if (power.type == AbstractPower.PowerType.BUFF) {
+		if (power.type == AbstractPower.PowerType.BUFF && !power.ID.equals(BackAttackPower.POWER_ID)) {
 			flashWithoutSound();
 			if (powerIDAmountMap.containsKey(power.ID)) {
 				powerIDAmountMap.put(power.ID, power.amount + powerIDAmountMap.get(power.ID));

--- a/src/main/java/thePackmaster/powers/thieverypack/MindControlledPower.java
+++ b/src/main/java/thePackmaster/powers/thieverypack/MindControlledPower.java
@@ -11,6 +11,7 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.random.Random;
 import thePackmaster.SpireAnniversary5Mod;
+import thePackmaster.patches.thieverypack.MindControlPatch;
 import thePackmaster.powers.AbstractPackmasterPower;
 
 public class MindControlledPower extends AbstractPackmasterPower {
@@ -64,7 +65,14 @@ public class MindControlledPower extends AbstractPackmasterPower {
 						isDone = true;
 					}
 				});
-				AbstractDungeon.actionManager.addToTop(new InstantKillAction(m));
+				AbstractDungeon.actionManager.addToTop(new InstantKillAction(m) {
+					@Override
+					public void update() {
+						MindControlPatch.SuicidePatch.enabled = false;
+						super.update();
+						MindControlPatch.SuicidePatch.enabled = true;
+					}
+				});
 			}
 		}
 	}

--- a/src/main/resources/anniv5Resources/localization/eng/thieverypack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/thieverypack/Cardstrings.json
@@ -9,7 +9,7 @@
   },
   "${ModID}:Smokescreen": {
     "NAME": "Smokescreen",
-    "DESCRIPTION": "ALL creatures gain !B! Block. NL ALL enemies lose !M! HP."
+    "DESCRIPTION": "EVERYONE gains !B! Block. NL ALL enemies lose !M! HP."
   },
   "${ModID}:NullHammer": {
     "NAME": "Null Hammer",
@@ -22,7 +22,7 @@
   },
   "${ModID}:StrengthSap": {
     "NAME": "Strength Sap",
-    "DESCRIPTION": "Apply !M! Weak. NL If the enemy has positive Strength, steal !${ModID}:m2! Strength."
+    "DESCRIPTION": "Apply !M! Weak. NL If the enemy has positive Strength, steal !${ModID}:m2! Strength. NL Exhaustive !stslib:ex!."
   },
   "${ModID}:CunningPoison": {
     "NAME": "Cunning Poison",
@@ -41,7 +41,7 @@
   },
   "${ModID}:ThieveryMastery": {
     "NAME": "Thievery Mastery",
-    "DESCRIPTION": "Whenever you steal something, gain 100% more of it. NL (Does not stack)",
-    "UPGRADE_DESCRIPTION": "Innate. NL Whenever you steal something, gain 100% more of it. NL (Does not stack)"
+    "DESCRIPTION": "You become a Master Thief. NL (Whenever you steal something, gain twice as much of it)",
+    "UPGRADE_DESCRIPTION": "Innate. NL You become a Master Thief. NL (Whenever you steal something, gain twice as much of it)"
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/thieverypack/Powerstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/thieverypack/Powerstrings.json
@@ -13,9 +13,9 @@
     ]
   },
   "${ModID}:ThieveryMasteryPower": {
-    "NAME": "Thievery Mastery",
+    "NAME": "Master Thief",
     "DESCRIPTIONS": [
-      "Whenever you steal something, gain #b100% more of it. Does NOT stack."
+      "Whenever you steal something, gain twice as much of it."
     ]
   },
   "${ModID}:MindControlledPower": {


### PR DESCRIPTION
Bug Fixes
- Null Hammer can no longer steal Back Attack power, preventing a softlock
- Fix Witchcraft not giving you a potion when you finish combat with it

Balance Changes
- Null Hammer can no longer steal the enemy's Strength and make them go below 0
  - This also fixes an inconsistency of whether you can steal the enemy's Strength or not. Previously, you could always steal the enemy's Strength, except when that enemy gains strength to 0 (causing the power icon to disappear). Now you can only steal when the enemy's strength goes over 0, and only steal positive portion of it.
- Fair Trade damage: 5(7) -> 6(8)
- Magnet cost: 1 -> 0
- Strength Sap stealing amount: 1(2) -> 1(1)
- Strength Sap now has Exhaustive 2(3)

Wording
- Changed the wording of Smokescreen(EVERYONE) and Thievery Mastery(Master Thief)

Code
- Used Reformat Code to remove unnecessary imports and fix formatting
