### PR TITLE
Changes to Grand Opening

### DIFF
--- a/src/main/java/thePackmaster/cards/grandopeningpack/Cross.java
+++ b/src/main/java/thePackmaster/cards/grandopeningpack/Cross.java
@@ -1,6 +1,7 @@
 package thePackmaster.cards.grandopeningpack;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.actions.common.MakeTempCardInDrawPileAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
@@ -9,6 +10,7 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.vfx.combat.ClashEffect;
 import thePackmaster.cards.AbstractPackmasterCard;
 import thePackmaster.powers.grandopeningpack.CrossPower;
 import thePackmaster.util.Wiz;
@@ -25,22 +27,10 @@ public class Cross extends AbstractGrandOpeningCard {
 
     @Override
     public void use(AbstractPlayer abstractPlayer, AbstractMonster abstractMonster) {
-        AbstractGameAction.AttackEffect slash = AbstractGameAction.AttackEffect.SLASH_HORIZONTAL;
-        AbstractGameAction.AttackEffect other_slash = AbstractGameAction.AttackEffect.SLASH_VERTICAL;
-        AbstractGameAction.AttackEffect temp_slash;
-
-        addToBot(new DamageAction(abstractMonster, new DamageInfo(abstractPlayer, this.damage, DamageInfo.DamageType.NORMAL), slash));
-        addToBot(new DamageAction(abstractMonster, new DamageInfo(abstractPlayer, this.damage, DamageInfo.DamageType.NORMAL), other_slash));
-        for(AbstractPower p : AbstractDungeon.player.powers){
-            if(CrossPower.POWER_ID.equals(p.ID)) {
-                for (int i = 0; i < p.amount; i++) {
-                    addToBot(new DamageAction(abstractMonster, new DamageInfo(abstractPlayer, this.damage, DamageInfo.DamageType.NORMAL), slash));
-                    temp_slash = slash;
-                    slash = other_slash;
-                    other_slash = temp_slash;
-                }
-            }
-        }
+        if (abstractMonster != null)
+            addToBot((AbstractGameAction)new VFXAction(new ClashEffect(abstractMonster.hb.cX, abstractMonster.hb.cY), 0.1F));
+        addToBot(new DamageAction(abstractMonster, new DamageInfo(abstractPlayer, this.damage, DamageInfo.DamageType.NORMAL), AbstractGameAction.AttackEffect.NONE));
+        addToBot(new DamageAction(abstractMonster, new DamageInfo(abstractPlayer, this.damage, DamageInfo.DamageType.NORMAL), AbstractGameAction.AttackEffect.NONE));
         Wiz.applyToSelf(new CrossPower(abstractPlayer, 1));
         AbstractCard cross = new Cross();
         if(this.upgraded){
@@ -50,16 +40,14 @@ public class Cross extends AbstractGrandOpeningCard {
     }
 
     public void applyPowers() {
-        this.baseMagicNumber = 2;
+        this.baseDamage = 2;
         for(AbstractPower p : AbstractDungeon.player.powers){
             if(CrossPower.POWER_ID.equals(p.ID)){
-                this.baseMagicNumber += p.amount;
+                this.baseDamage += p.amount;
+                this.isDamageModified = true;
             }
         }
         super.applyPowers();
-        this.rawDescription = cardStrings.DESCRIPTION + cardStrings.EXTENDED_DESCRIPTION[0];
-        if(this.upgraded)
-            this.rawDescription = cardStrings.UPGRADE_DESCRIPTION + cardStrings.EXTENDED_DESCRIPTION[0];
         initializeDescription();
     }
 

--- a/src/main/java/thePackmaster/cards/grandopeningpack/MessUp.java
+++ b/src/main/java/thePackmaster/cards/grandopeningpack/MessUp.java
@@ -41,9 +41,9 @@ public class MessUp extends AbstractGrandOpeningCard {
                 addToBot((AbstractGameAction) new ShuffleAction(AbstractDungeon.player.drawPile, false));
             }
         }
-        this.rawDescription = cardStrings.DESCRIPTION;
+        this.rawDescription = cardStrings.EXTENDED_DESCRIPTION[0] + cardStrings.DESCRIPTION;
         if(this.upgraded){
-            this.rawDescription = cardStrings.UPGRADE_DESCRIPTION;
+            this.rawDescription = cardStrings.EXTENDED_DESCRIPTION[0] + cardStrings.UPGRADE_DESCRIPTION;
         }
         initializeDescription();
     }
@@ -54,18 +54,18 @@ public class MessUp extends AbstractGrandOpeningCard {
                 this.baseDamage += AbstractDungeon.player.discardPile.size();
             }
             super.applyPowers();
-            this.rawDescription = cardStrings.DESCRIPTION + cardStrings.EXTENDED_DESCRIPTION[0];
+            this.rawDescription = cardStrings.EXTENDED_DESCRIPTION[0] + cardStrings.DESCRIPTION;
             if(this.upgraded){
-                this.rawDescription = cardStrings.UPGRADE_DESCRIPTION + cardStrings.EXTENDED_DESCRIPTION[0];
+                this.rawDescription = cardStrings.EXTENDED_DESCRIPTION[0] + cardStrings.UPGRADE_DESCRIPTION;
             }
             initializeDescription();
         }
 
         public void calculateCardDamage(AbstractMonster mo) {
             super.calculateCardDamage(mo);
-            this.rawDescription = cardStrings.DESCRIPTION + cardStrings.EXTENDED_DESCRIPTION[0];
+            this.rawDescription = cardStrings.EXTENDED_DESCRIPTION[0] + cardStrings.DESCRIPTION;
             if(this.upgraded){
-                this.rawDescription = cardStrings.UPGRADE_DESCRIPTION + cardStrings.EXTENDED_DESCRIPTION[0];
+                this.rawDescription = cardStrings.EXTENDED_DESCRIPTION[0] + cardStrings.UPGRADE_DESCRIPTION;
             }
             initializeDescription();
         }

--- a/src/main/java/thePackmaster/cards/grandopeningpack/PlannedDefense.java
+++ b/src/main/java/thePackmaster/cards/grandopeningpack/PlannedDefense.java
@@ -19,7 +19,7 @@ public class PlannedDefense extends AbstractGrandOpeningCard {
     public PlannedDefense() {
         super(ID, 2, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
         this.isInnate = true;
-        this.baseBlock = this.block = 20;
+        this.baseBlock = this.block = 15;
     }
 
     @Override
@@ -39,6 +39,6 @@ public class PlannedDefense extends AbstractGrandOpeningCard {
 
     @Override
     public void upp() {
-        this.upgradeBlock(3);
+        this.upgradeBlock(4);
     }
 }

--- a/src/main/java/thePackmaster/cards/grandopeningpack/PlannedDefense.java
+++ b/src/main/java/thePackmaster/cards/grandopeningpack/PlannedDefense.java
@@ -19,7 +19,7 @@ public class PlannedDefense extends AbstractGrandOpeningCard {
     public PlannedDefense() {
         super(ID, 2, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
         this.isInnate = true;
-        this.baseBlock = this.block = 12;
+        this.baseBlock = this.block = 20;
     }
 
     @Override
@@ -33,7 +33,7 @@ public class PlannedDefense extends AbstractGrandOpeningCard {
             }
         }
         if (innatePlayed) {
-            addToBot((AbstractGameAction) new ApplyPowerAction((AbstractCreature) p, (AbstractCreature) p, (AbstractPower) new NextTurnBlockPower((AbstractCreature) p, this.block), this.block));
+            addToBot((AbstractGameAction) new ApplyPowerAction((AbstractCreature) p, (AbstractCreature) p, (AbstractPower) new NextTurnBlockPower((AbstractCreature) p, this.block/2), this.block/2));
         }
     }
 

--- a/src/main/java/thePackmaster/cards/grandopeningpack/Surge.java
+++ b/src/main/java/thePackmaster/cards/grandopeningpack/Surge.java
@@ -27,6 +27,6 @@ public class Surge extends AbstractGrandOpeningCard {
 
     @Override
     public void upp() {
-        upgradeMagicNumber(1);
+        this.isInnate = true;
     }
 }

--- a/src/main/java/thePackmaster/powers/grandopeningpack/CrossPower.java
+++ b/src/main/java/thePackmaster/powers/grandopeningpack/CrossPower.java
@@ -16,8 +16,6 @@ public class CrossPower extends AbstractPackmasterPower {
     }
 
     public void updateDescription() {
-        if(this.amount==1){
-            this.description = DESCRIPTIONS[0] + this.amount + DESCRIPTIONS[1];
-        } else this.description = DESCRIPTIONS[0] + this.amount + DESCRIPTIONS[2];
+        this.description = DESCRIPTIONS[0] + this.amount + DESCRIPTIONS[1];
     }
 }

--- a/src/main/java/thePackmaster/powers/grandopeningpack/DebutPower.java
+++ b/src/main/java/thePackmaster/powers/grandopeningpack/DebutPower.java
@@ -28,6 +28,10 @@ public class DebutPower extends AbstractPackmasterPower {
             addToBot(new GainEnergyAction(min(this.amount, card.costForTurn)));
             this.triggered = true;
         }
+        if(card.isInnate && card.costForTurn == -1 && !this.triggered) {
+            addToBot(new GainEnergyAction(min(this.amount, card.energyOnUse)));
+            this.triggered = true;
+        }
     }
 
     public void updateDescription() {

--- a/src/main/resources/anniv5Resources/localization/eng/grandopeningpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/grandopeningpack/Cardstrings.json
@@ -4,16 +4,16 @@
     "DESCRIPTION": "Deal damage equal to the amount of cards in your draw pile. NL Shuffle your Discard pile into your draw pile.",
     "UPGRADE_DESCRIPTION": "Shuffle your Discard pile into your deck. NL Deal damage equal to the amount of cards in your draw pile.",
     "EXTENDED_DESCRIPTION": [
-      " NL (Deals !D! damage.)"
+      "(Deals !D! damage.) NL "
     ]
   },
   "${ModID}:PlannedDefense": {
     "NAME": "Planned Defense",
-    "DESCRIPTION": "Innate. NL Gain !B! Block. If you played another Innate card this turn, also gain !B! Block next turn."
+    "DESCRIPTION": "Innate. NL Gain !B! Block. If you played another Innate card this turn, also gain half that much Block next turn."
   },
   "${ModID}:SecondStrike": {
     "NAME": "Second Strike",
-    "DESCRIPTION": "Innate. Retain. NL Deal !D! damage. If it is not the first turn, play this again."
+    "DESCRIPTION": "Innate. Retain. NL Deal !D! damage. If it is not the first turn, deal !D! damage again."
   },
   "${ModID}:DashIn": {
     "NAME": "Dash In",
@@ -26,11 +26,8 @@
   },
   "${ModID}:Cross": {
     "NAME": "Cross",
-    "DESCRIPTION": "Deal !D! damage twice. Hits one more time for each of your created *Crosses. Shuffle a *Cross into your draw pile.",
-    "UPGRADE_DESCRIPTION": "Innate. NL Deal !D! damage twice. Hits one more time for each of your created *Crosses. Shuffle a *Cross+ into your draw pile.",
-    "EXTENDED_DESCRIPTION": [
-      " NL (Hits !M! times.)"
-    ]
+    "DESCRIPTION": "Deal !D! damage twice. Your *Crosses deal 1 more damage this combat. Shuffle a *Cross into your draw pile.",
+    "UPGRADE_DESCRIPTION": "Innate. NL Deal !D! damage twice. Your *Crosses deal 1 more damage this combat. Shuffle a *Cross+ into your draw pile."
   },
   "${ModID}:Improvise": {
     "NAME": "Improvise",
@@ -53,6 +50,6 @@
   "${ModID}:Surge": {
     "NAME": "Surge",
     "DESCRIPTION": "This turn, your next Innate card is played twice.",
-    "UPGRADE_DESCRIPTION": "This turn, your next !M! Innate cards are played twice."
+    "UPGRADE_DESCRIPTION": "Innate. NL This turn, your next Innate card is played twice."
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/grandopeningpack/Powerstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/grandopeningpack/Powerstrings.json
@@ -2,9 +2,8 @@
   "${ModID}:CrossPower": {
     "NAME": "Cross",
     "DESCRIPTIONS": [
-      "Your #yCrosses hit #b",
-      " additional time.",
-      " additional times."
+      "Your #yCrosses deal #b",
+      " additional damage."
     ]
   },
   "${ModID}:InstinctsPower": {


### PR DESCRIPTION
-Cross always hits twice but scales its damage, PlannedDefense gains more block and less block next turn, Surge upgrades to becoming Innate and MessUp has its damage total at the top. Also, debut with dashin has been fixed, used to not trigger on X-costs.