### PR TITLE
Loading fix for different languages, different color clarification, Plasma Shield power text update

### DIFF
--- a/src/main/java/thePackmaster/SpireAnniversary5Mod.java
+++ b/src/main/java/thePackmaster/SpireAnniversary5Mod.java
@@ -513,7 +513,7 @@ public class SpireAnniversary5Mod implements
     private String getLangString() {
         for (Settings.GameLanguage lang : SupportedLanguages) {
             if (lang.equals(Settings.language)) {
-                return Settings.language.name().toLowerCase();
+                return Settings.language.name().toLowerCase(Locale.ROOT);
             }
         }
         return "eng";
@@ -549,7 +549,7 @@ public class SpireAnniversary5Mod implements
         logger.info("Found pack classes with AutoAdd: " + packClasses.size());
 
         for (CtClass packClass : packClasses) {
-            String packName = packClass.getSimpleName().toLowerCase();
+            String packName = packClass.getSimpleName().toLowerCase(Locale.ROOT);
             String languageAndPack = getLangString() + "/" + packName;
             logger.info("Loading strings for pack " + packClass.getName() + "from \"resources/localization/" + languageAndPack + "\"");
             //Do not need to be checked as these always need to exist
@@ -591,7 +591,7 @@ public class SpireAnniversary5Mod implements
                 .collect(Collectors.toList());
 
         for (CtClass packClass : packClasses) {
-            String packName = packClass.getSimpleName().toLowerCase();
+            String packName = packClass.getSimpleName().toLowerCase(Locale.ROOT);
             String languageAndPack = getLangString() + "/" + packName;
             logger.info("Loading keywords for pack " + packClass.getName() + "from \"resources/localization/" + languageAndPack + "\"");
             String packJson = modID + "Resources/localization/" + languageAndPack + "/Keywordstrings.json";

--- a/src/main/java/thePackmaster/cards/dragonwrathpack/AbstractDragonwrathCard.java
+++ b/src/main/java/thePackmaster/cards/dragonwrathpack/AbstractDragonwrathCard.java
@@ -4,6 +4,8 @@ import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.ThePackmaster;
 import thePackmaster.cards.AbstractPackmasterCard;
 
+import java.util.Locale;
+
 public abstract class AbstractDragonwrathCard extends AbstractPackmasterCard
 {
     public AbstractDragonwrathCard(String cardID, int cost, CardType type, CardRarity rarity, CardTarget target, CardColor color) {
@@ -11,8 +13,8 @@ public abstract class AbstractDragonwrathCard extends AbstractPackmasterCard
 
         if (!SpireAnniversary5Mod.oneFrameMode) {
             setBackgroundTexture(
-                    "anniv5Resources/images/512/dragonwrath/" + type.name().toLowerCase() + ".png",
-                    "anniv5Resources/images/1024/dragonwrath/" + type.name().toLowerCase() + ".png"
+                    "anniv5Resources/images/512/dragonwrath/" + type.name().toLowerCase(Locale.ROOT) + ".png",
+                    "anniv5Resources/images/1024/dragonwrath/" + type.name().toLowerCase(Locale.ROOT) + ".png"
             );
             setOrbTexture(
                     "anniv5Resources/images/512/dragonwrath/orb.png",

--- a/src/main/java/thePackmaster/cards/farmerpack/AbstractFarmerCard.java
+++ b/src/main/java/thePackmaster/cards/farmerpack/AbstractFarmerCard.java
@@ -7,13 +7,14 @@ import thePackmaster.ThePackmaster;
 import thePackmaster.cards.AbstractPackmasterCard;
 
 import java.util.Iterator;
+import java.util.Locale;
 
 public abstract class AbstractFarmerCard extends AbstractPackmasterCard {
     public AbstractFarmerCard(String cardID, int cost, CardType type, CardRarity rarity, CardTarget target, CardColor color) {
         super(cardID, cost, type, rarity, target, color);
         setBackgroundTexture(
-                "anniv5Resources/images/512/farmer/" + type.name().toLowerCase() + ".png",
-                "anniv5Resources/images/1024/farmer/" + type.name().toLowerCase() + ".png"
+                "anniv5Resources/images/512/farmer/" + type.name().toLowerCase(Locale.ROOT) + ".png",
+                "anniv5Resources/images/1024/farmer/" + type.name().toLowerCase(Locale.ROOT) + ".png"
         );
     }
 

--- a/src/main/java/thePackmaster/cards/rippack/AbstractRippableCard.java
+++ b/src/main/java/thePackmaster/cards/rippack/AbstractRippableCard.java
@@ -19,6 +19,7 @@ import thePackmaster.vfx.rippack.ShowCardAndRipEffect;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 import static thePackmaster.util.Wiz.att;
@@ -35,8 +36,8 @@ public abstract class AbstractRippableCard extends AbstractRipCard {
 
         if (!SpireAnniversary5Mod.oneFrameMode)
             setBackgroundTexture(
-                    "anniv5Resources/images/512/rip/" + type.name().toLowerCase() + "-rippable.png",
-                    "anniv5Resources/images/1024/rip/" + type.name().toLowerCase() + "-rippable.png"
+                    "anniv5Resources/images/512/rip/" + type.name().toLowerCase(Locale.ROOT) + "-rippable.png",
+                    "anniv5Resources/images/1024/rip/" + type.name().toLowerCase(Locale.ROOT) + "-rippable.png"
             );
     }
 

--- a/src/main/java/thePackmaster/cards/womaninbluepack/AbstractWomanInBlueModalChoiceCard.java
+++ b/src/main/java/thePackmaster/cards/womaninbluepack/AbstractWomanInBlueModalChoiceCard.java
@@ -4,6 +4,8 @@ import basemod.AutoAdd;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.cards.PackmasterModalChoiceCard;
 
+import java.util.Locale;
+
 @AutoAdd.Ignore
 public class AbstractWomanInBlueModalChoiceCard extends PackmasterModalChoiceCard {
     public AbstractWomanInBlueModalChoiceCard(String ID, String name, String description, boolean usePackFrame, Runnable onUseOrChosen) {
@@ -11,8 +13,8 @@ public class AbstractWomanInBlueModalChoiceCard extends PackmasterModalChoiceCar
 
         if (!SpireAnniversary5Mod.oneFrameMode)
             setBackgroundTexture(
-                "anniv5Resources/images/512/womaninblue/" + type.name().toLowerCase() + ".png",
-                "anniv5Resources/images/1024/womaninblue/" + type.name().toLowerCase() + ".png"
+                "anniv5Resources/images/512/womaninblue/" + type.name().toLowerCase(Locale.ROOT) + ".png",
+                "anniv5Resources/images/1024/womaninblue/" + type.name().toLowerCase(Locale.ROOT) + ".png"
         );
     }
 

--- a/src/main/java/thePackmaster/hats/Hats.java
+++ b/src/main/java/thePackmaster/hats/Hats.java
@@ -18,6 +18,8 @@ import thePackmaster.util.ImageHelper;
 import thePackmaster.util.TexLoader;
 import thePackmaster.util.Wiz;
 
+import java.util.Locale;
+
 import static thePackmaster.hats.HatMenu.specialHats;
 
 public class Hats {
@@ -90,7 +92,7 @@ public class Hats {
 
         Array<Bone> possiblebones = skeleton.getBones();
         for (Bone b : possiblebones) {
-            bonename = b.toString().toLowerCase();
+            bonename = b.toString().toLowerCase(Locale.ROOT);
             if (bonename.equals("head")) {
                 if (isDummy)
                     headbone = b;
@@ -104,7 +106,7 @@ public class Hats {
 
         Array<Slot> possibleslots = skeleton.getSlots();
         for (Slot s : possibleslots) {
-            slotname = s.getBone().toString().toLowerCase();
+            slotname = s.getBone().toString().toLowerCase(Locale.ROOT);
             if (slotname.equals("head")) {
                 if (isDummy) {
                     headslot = s;

--- a/src/main/java/thePackmaster/patches/odditiespack/FoilShiny.java
+++ b/src/main/java/thePackmaster/patches/odditiespack/FoilShiny.java
@@ -19,6 +19,7 @@ import thePackmaster.util.ImageHelper;
 
 import java.nio.IntBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 public class FoilShiny {
     @SpirePatch(clz = AbstractCard.class, method = "render", paramtypez = SpriteBatch.class)
@@ -29,7 +30,7 @@ public class FoilShiny {
 
         private static int RUNNING_ON_STEAM_DECK = -1;
 
-        private static final String OS = System.getProperty("os.name").toLowerCase();
+        private static final String OS = System.getProperty("os.name").toLowerCase(Locale.ROOT);
         public static boolean IS_WINDOWS = (OS.indexOf("win") >= 0);
 
         public static boolean isOnSteamDeck() {

--- a/src/main/java/thePackmaster/patches/odditiespack/PackmasterFoilPatches.java
+++ b/src/main/java/thePackmaster/patches/odditiespack/PackmasterFoilPatches.java
@@ -15,6 +15,7 @@ import thePackmaster.SpireAnniversary5Mod;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Locale;
 
 public class PackmasterFoilPatches {
 
@@ -37,7 +38,7 @@ public class PackmasterFoilPatches {
                 case ATTACK:
                 case SKILL:
                 case POWER:
-                    ((CustomCard) card).setBackgroundTexture(SpireAnniversary5Mod.modID + "Resources/images/512/" + card.type.toString().toLowerCase() + "_foil.png", "fishingResources/images/1024/" + card.type.toString().toLowerCase() + "_foil.png");
+                    ((CustomCard) card).setBackgroundTexture(SpireAnniversary5Mod.modID + "Resources/images/512/" + card.type.toString().toLowerCase(Locale.ROOT) + "_foil.png", "fishingResources/images/1024/" + card.type.toString().toLowerCase() + "_foil.png");
                     break;
             }
         }

--- a/src/main/resources/anniv5Resources/localization/eng/pixiepack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/pixiepack/Keywordstrings.json
@@ -1,14 +1,9 @@
 [
   {
-    "PROPER_NAME": "Different Color",
-    "NAMES": ["different\u00a0color"],
-    "DESCRIPTION": "Any color other than your character's normal card color."
-  },
-  {
     "PROPER_NAME": "Enchantment",
     "NAMES": [
       "enchantment","Enchantment"
     ],
-    "DESCRIPTION": "When you play a card with a different color any applicable #yEnchantments are copied and played onto the same target."
+    "DESCRIPTION": "When you play a card with a #ydifferent #ycolor any applicable #yEnchantments are copied and played onto the same target. (A different color is any color other than your character's normal card color; different Packmaster packs are not different colors.)"
   }
 ]

--- a/src/main/resources/anniv5Resources/localization/eng/prismaticpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/prismaticpack/Keywordstrings.json
@@ -2,6 +2,6 @@
   {
     "PROPER_NAME": "Different Color",
     "NAMES": ["different\u00a0color"],
-    "DESCRIPTION": "Any color other than your character's normal card color."
+    "DESCRIPTION": "Any color other than your character's normal card color. Different Packmaster packs are not different colors."
   }
 ]

--- a/src/main/resources/anniv5Resources/localization/eng/utilitypack/Powerstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/utilitypack/Powerstrings.json
@@ -1,6 +1,6 @@
 {
   "${ModID}:PlasmaShield": {
     "NAME": "Plasma Shield",
-    "DESCRIPTIONS": ["At the end of your turn, gain #b{0} #yBlock for each #yPlasma."]
+    "DESCRIPTIONS": ["At the end of your turn, gain #b{0} #yBlock if you have #yPlasma."]
   }
 }


### PR DESCRIPTION
* General fix: fix the Packmaster not being able to load in languages that have special behavior when changing letters between uppercase and lowercase
* Utility pack: fix Plasma Shield power description being outdated
* Pixie pack: clarify that Enchantments do not trigger when cards from different Packmaster packs are played

For the language issue, Turkish is an example of a language that does strange things with upper letter "I". There's a bunch of explanations of this in various places, https://stackoverflow.com/questions/11063102/using-locales-with-javas-tolowercase-and-touppercase was the first one I found on Google.

For the Pixie pack/enchantment thing, it's clear from monitoring the bugs thread that a lot of people are confused by this. I've made the keywords more verbose as an attempt to address this (and consolidated the two copies of the different color keyword into one). If there's still confusion over this, we could consider using a different word entirely, like what Downfall uses ("Offclass", if I'm remembering correctly).

The third commit is just a fix to an outdated power description in my Utility pack.