### PR TITLE
Heavy is the head that wears the Clawn...

### DIFF
--- a/src/main/java/thePackmaster/SpireAnniversary5Mod.java
+++ b/src/main/java/thePackmaster/SpireAnniversary5Mod.java
@@ -231,7 +231,6 @@ public class SpireAnniversary5Mod implements
     public static boolean selectedCards = false;
     public static int combatExhausts = 0;
 
-    public static int CLAW_SHARP_TRACKER = 0;
 
     public static String makeID(String idText) {
         return modID + ":" + idText;
@@ -660,7 +659,6 @@ public class SpireAnniversary5Mod implements
     public void receiveOnBattleStart(AbstractRoom room) {
         pandaList.clear();
         UltimateHomerun.HIGH_SCORE = 0;
-        CLAW_SHARP_TRACKER = 0;
         combatExhausts = 0;
         PenancePower.Power = 20;
         MindControlledPower.targetRng = new Random(Settings.seed + AbstractDungeon.floorNum);

--- a/src/main/java/thePackmaster/actions/dimensiongatepack/HoardPayoffAction.java
+++ b/src/main/java/thePackmaster/actions/dimensiongatepack/HoardPayoffAction.java
@@ -13,8 +13,8 @@ public class HoardPayoffAction extends AbstractGameAction {
     AbstractCard card = null;
     private Runnable payoff;
 
-    public HoardPayoffAction(AbstractCard IN_ferno, Runnable payoff) {
-        card = IN_ferno;
+    public HoardPayoffAction(AbstractCard hoardCard, Runnable payoff) {
+        card = hoardCard;
         this.payoff = payoff;
     }
 
@@ -22,24 +22,44 @@ public class HoardPayoffAction extends AbstractGameAction {
     public void update() {
         this.isDone = true;
 
-        if (card.energyOnUse < EnergyPanel.totalCount) {
-            card.energyOnUse = EnergyPanel.totalCount;
+        if (card.cost == -1) {
+            if (card.energyOnUse < EnergyPanel.totalCount) {
+                card.energyOnUse = EnergyPanel.totalCount;
+            }
+            if (Wiz.p().hasRelic(ChemicalX.ID)) {
+                card.energyOnUse = card.energyOnUse + 2;
+            }
         }
-        if (Wiz.p().hasRelic(ChemicalX.ID)) {
-            card.energyOnUse = card.energyOnUse + 2;
-        }
+
         if (HoardField.hoard.get(card) > 0) {
-            HoardField.decrement(card, card.energyOnUse);
+            if (card.cost == -1){
+                HoardField.decrement(card, card.energyOnUse);
+            } else {
+                HoardField.decrement(card, Wiz.getLogicalCardCost(card));
+            }
             if (HoardField.hoard.get(card) <= 0) {
+                card.returnToHand = false;
                 payoff.run();
                 HoardField.resetValueToBase(card);
+            } else {
+                if ((card.cost == -1 && card.energyOnUse > 0) || (Wiz.getLogicalCardCost(card) > 0)) {
+                    card.returnToHand = true;
+                    card.retain = true;
+                } else {
+                    //If Hoard was used this turn, then the card is played later for 0-cost (most common on an X-Cost)
+                    //then we should not be returning it to hand on this activation per how the keyword states it works.
+                    card.returnToHand = false;
+                }
             }
         } else {
+            card.returnToHand = false;
             payoff.run();
             HoardField.resetValueToBase(card);
         }
-        if (!card.freeToPlayOnce) {
-            AbstractDungeon.player.energy.use(EnergyPanel.totalCount);
+        if (card.cost == -1) {
+            if (!card.freeToPlayOnce) {
+                AbstractDungeon.player.energy.use(EnergyPanel.totalCount);
+            }
         }
     }
 }

--- a/src/main/java/thePackmaster/actions/dimensiongatepack/HoardPayoffAction.java
+++ b/src/main/java/thePackmaster/actions/dimensiongatepack/HoardPayoffAction.java
@@ -20,46 +20,13 @@ public class HoardPayoffAction extends AbstractGameAction {
 
     @Override
     public void update() {
+
         this.isDone = true;
-
-        if (card.cost == -1) {
-            if (card.energyOnUse < EnergyPanel.totalCount) {
-                card.energyOnUse = EnergyPanel.totalCount;
-            }
-            if (Wiz.p().hasRelic(ChemicalX.ID)) {
-                card.energyOnUse = card.energyOnUse + 2;
-            }
-        }
-
-        if (HoardField.hoard.get(card) > 0) {
-            if (card.cost == -1){
-                HoardField.decrement(card, card.energyOnUse);
-            } else {
-                HoardField.decrement(card, Wiz.getLogicalCardCost(card));
-            }
-            if (HoardField.hoard.get(card) <= 0) {
-                card.returnToHand = false;
-                payoff.run();
-                HoardField.resetValueToBase(card);
-            } else {
-                if ((card.cost == -1 && card.energyOnUse > 0) || (Wiz.getLogicalCardCost(card) > 0)) {
-                    card.returnToHand = true;
-                    card.retain = true;
-                } else {
-                    //If Hoard was used this turn, then the card is played later for 0-cost (most common on an X-Cost)
-                    //then we should not be returning it to hand on this activation per how the keyword states it works.
-                    card.returnToHand = false;
-                }
-            }
-        } else {
-            card.returnToHand = false;
+        if (HoardField.hoard.get(card) <= 1){
             payoff.run();
             HoardField.resetValueToBase(card);
-        }
-        if (card.cost == -1) {
-            if (!card.freeToPlayOnce) {
-                AbstractDungeon.player.energy.use(EnergyPanel.totalCount);
-            }
+        } else {
+            HoardField.decrement(card, 1);
         }
     }
 }

--- a/src/main/java/thePackmaster/cardmodifiers/clawpack/AddClawTagAndMakeClawModifier.java
+++ b/src/main/java/thePackmaster/cardmodifiers/clawpack/AddClawTagAndMakeClawModifier.java
@@ -25,7 +25,7 @@ public class AddClawTagAndMakeClawModifier extends AbstractMadScienceModifierWit
             card.applyPowers();
         }
         if (card.cardsToPreview == null){
-            card.cardsToPreview = new GhostClaw(true);
+            card.cardsToPreview = new GhostClaw();
         }
     }
 

--- a/src/main/java/thePackmaster/cardmodifiers/clawpack/MakeClawModifier.java
+++ b/src/main/java/thePackmaster/cardmodifiers/clawpack/MakeClawModifier.java
@@ -29,7 +29,7 @@ public class MakeClawModifier extends AbstractMadScienceModifier {
     public void onInitialApplication(AbstractCard card) {
         super.onInitialApplication(card);
         if (card.cardsToPreview == null){
-            card.cardsToPreview = new GhostClaw(true);
+            card.cardsToPreview = new GhostClaw();
         }
     }
 

--- a/src/main/java/thePackmaster/cards/clawpack/AbstractClawCard.java
+++ b/src/main/java/thePackmaster/cards/clawpack/AbstractClawCard.java
@@ -22,20 +22,19 @@ public abstract class AbstractClawCard extends AbstractPackmasterCard {
 
 
     public static void ClawUp(int value) {
-    ClawUp(value, false);
+        ClawUp(value, false);
     }
 
     public static void ClawUp(int value, boolean excludeClaws) {
 
-        SpireAnniversary5Mod.CLAW_SHARP_TRACKER += value;
 
         ArrayList<AbstractCard> cards = new ArrayList<>();
         cards.addAll(AbstractDungeon.player.hand.group);
         cards.addAll(AbstractDungeon.player.drawPile.group);
         cards.addAll(AbstractDungeon.player.discardPile.group);
-        
+
         for (AbstractCard c : cards) {
-            if (!(excludeClaws && (c instanceof Claw)) && c.hasTag(SpireAnniversary5Mod.CLAW)) {
+            if (!(excludeClaws && (c instanceof Claw)) && c.hasTag(SpireAnniversary5Mod.CLAW) && c.baseDamage > 0) {
                 c.baseDamage += value;
                 c.applyPowers();
                 if (AbstractDungeon.player.hand.group.contains(c)) {

--- a/src/main/java/thePackmaster/cards/clawpack/Alclawmize.java
+++ b/src/main/java/thePackmaster/cards/clawpack/Alclawmize.java
@@ -4,7 +4,7 @@ import com.megacrit.cardcrawl.actions.common.ObtainPotionAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.helpers.PotionHelper;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
-import com.megacrit.cardcrawl.potions.*;
+import com.megacrit.cardcrawl.potions.AbstractPotion;
 import thePackmaster.potions.clawpack.AttackPotionButClaw;
 import thePackmaster.potions.clawpack.ClawPowerPotion;
 import thePackmaster.potions.clawpack.DrawClawsPotion;
@@ -20,9 +20,10 @@ public class Alclawmize extends AbstractClawCard {
     public final static String ID = makeID("Alclawmize");
 
     ArrayList<String> potions = new ArrayList<>();
+
     public Alclawmize() {
         super(ID, 1, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
-        exhaust=true;
+        exhaust = true;
         tags.add(CardTags.HEALING);
         tags.add(CLAW);
 

--- a/src/main/java/thePackmaster/cards/clawpack/ClawForOne.java
+++ b/src/main/java/thePackmaster/cards/clawpack/ClawForOne.java
@@ -6,17 +6,11 @@ import com.evacipated.cardcrawl.mod.stslib.actions.common.MoveCardsAction;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
-import com.megacrit.cardcrawl.actions.defect.DiscardPileToHandAction;
-import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.vfx.combat.ClawEffect;
 import thePackmaster.util.Wiz;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.function.Predicate;
 
 import static thePackmaster.SpireAnniversary5Mod.CLAW;
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -40,7 +34,9 @@ public class ClawForOne extends AbstractClawCard {
             @Override
             public void update() {
                 this.isDone = true;
-                addToBot(new MoveCardsAction(p.hand, p.discardPile, (c) -> { return (c.hasTag(CLAW) && c != ClawForOne.this); }, BaseMod.MAX_HAND_SIZE));
+                addToBot(new MoveCardsAction(p.hand, p.discardPile, (c) -> {
+                    return (c.hasTag(CLAW) && c != ClawForOne.this);
+                }, BaseMod.MAX_HAND_SIZE));
             }
         });
     }

--- a/src/main/java/thePackmaster/cards/clawpack/CloakAndClaw.java
+++ b/src/main/java/thePackmaster/cards/clawpack/CloakAndClaw.java
@@ -17,7 +17,7 @@ public class CloakAndClaw extends AbstractClawCard {
         baseBlock = 6;
         baseMagicNumber = magicNumber = 1;
         tags.add(CLAW);
-        cardsToPreview = new GhostClaw(true);
+        cardsToPreview = new GhostClaw();
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/clawpack/Conclawd.java
+++ b/src/main/java/thePackmaster/cards/clawpack/Conclawd.java
@@ -3,10 +3,8 @@ package thePackmaster.cards.clawpack;
 import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
-import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.actions.common.DamageAllEnemiesAction;
 import com.megacrit.cardcrawl.actions.watcher.PressEndTurnButtonAction;
-import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.vfx.combat.ClawEffect;
@@ -23,12 +21,12 @@ public class Conclawd extends AbstractClawCard {
         baseDamage = 10;
         baseMagicNumber = magicNumber = 2;
         tags.add(CLAW);
-isMultiDamage = true;
+        isMultiDamage = true;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
-        for (AbstractMonster m2:Wiz.getEnemies()
-             ) {
+        for (AbstractMonster m2 : Wiz.getEnemies()
+        ) {
             this.addToBot(new VFXAction(new ClawEffect(m2.hb.cX, m2.hb.cY, Color.PURPLE, Color.WHITE), 0.1F));
         }
 

--- a/src/main/java/thePackmaster/cards/clawpack/GhostClaw.java
+++ b/src/main/java/thePackmaster/cards/clawpack/GhostClaw.java
@@ -8,7 +8,6 @@ import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.vfx.combat.ClawEffect;
-import thePackmaster.SpireAnniversary5Mod;
 
 import static thePackmaster.SpireAnniversary5Mod.CLAW;
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -16,18 +15,11 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 public class GhostClaw extends AbstractClawCard {
     public final static String ID = makeID("GhostClaw");
 
-    public GhostClaw() {
-        this(false);
-    }
 
-    public GhostClaw(boolean isPreview) {
+    public GhostClaw() {
         super(ID, 0, CardType.ATTACK, CardRarity.SPECIAL, CardTarget.ENEMY, CardColor.COLORLESS);
-        if (isPreview){
-            baseDamage = 2;
-        } else {
-            baseDamage = 2 + SpireAnniversary5Mod.CLAW_SHARP_TRACKER;
-        }
-        baseMagicNumber = magicNumber = 1;
+        baseDamage = 3;
+        baseMagicNumber = magicNumber = 2;
         tags.add(CLAW);
         exhaust = true;
     }
@@ -42,7 +34,6 @@ public class GhostClaw extends AbstractClawCard {
     }
 
     public void upp() {
-        upgradeDamage(1);
-        upgradeMagicNumber(1);
+        upgradeDamage(2);
     }
 }

--- a/src/main/java/thePackmaster/cards/clawpack/InfiniteClaws.java
+++ b/src/main/java/thePackmaster/cards/clawpack/InfiniteClaws.java
@@ -1,19 +1,11 @@
 package thePackmaster.cards.clawpack;
 
-import com.megacrit.cardcrawl.actions.AbstractGameAction;
-import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
-import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
-import com.megacrit.cardcrawl.powers.StrengthPower;
-import thePackmaster.SpireAnniversary5Mod;
-import thePackmaster.cards.AbstractPackmasterCard;
 import thePackmaster.powers.clawpack.InfiniteClawsPower;
 import thePackmaster.util.Wiz;
-
-import java.util.HashSet;
 
 import static thePackmaster.SpireAnniversary5Mod.CLAW;
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -24,7 +16,7 @@ public class InfiniteClaws extends AbstractClawCard {
 
     public InfiniteClaws() {
         super(ID, 1, CardType.POWER, CardRarity.UNCOMMON, CardTarget.SELF);
-        cardsToPreview = new GhostClaw(true);
+        cardsToPreview = new GhostClaw();
         tags.add(CLAW);
     }
 

--- a/src/main/java/thePackmaster/cards/clawpack/MutateClaw.java
+++ b/src/main/java/thePackmaster/cards/clawpack/MutateClaw.java
@@ -5,9 +5,6 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePackmaster.actions.madsciencepack.FindCardForAddModifierAction;
 import thePackmaster.cardmodifiers.clawpack.AddClawTagAndMakeClawModifier;
-import thePackmaster.cardmodifiers.madsciencepack.AddDamageModifier;
-
-import java.util.ArrayList;
 
 import static thePackmaster.SpireAnniversary5Mod.CLAW;
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -17,17 +14,17 @@ public class MutateClaw extends AbstractClawCard {
 
     public MutateClaw() {
         super(ID, 0, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
-        exhaust=true;
-        cardsToPreview = new GhostClaw(true);
+        exhaust = true;
+        cardsToPreview = new GhostClaw();
         tags.add(CLAW);
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
-        addToBot(new FindCardForAddModifierAction(new AddClawTagAndMakeClawModifier(magicNumber),1,false, AbstractDungeon.player.hand, card->card.type==CardType.ATTACK));
+        addToBot(new FindCardForAddModifierAction(new AddClawTagAndMakeClawModifier(magicNumber), 1, false, AbstractDungeon.player.hand, card -> card.type == CardType.ATTACK));
 
     }
 
     public void upp() {
-        exhaust=false;
+        exhaust = false;
     }
 }

--- a/src/main/java/thePackmaster/cards/clawpack/PMClaw.java
+++ b/src/main/java/thePackmaster/cards/clawpack/PMClaw.java
@@ -1,7 +1,6 @@
 package thePackmaster.cards.clawpack;
 
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
@@ -10,7 +9,6 @@ import com.megacrit.cardcrawl.cards.blue.Claw;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.vfx.combat.ClawEffect;
-import thePackmaster.ThePackmaster;
 
 import static thePackmaster.SpireAnniversary5Mod.CLAW;
 import static thePackmaster.SpireAnniversary5Mod.makeID;

--- a/src/main/java/thePackmaster/cards/clawpack/SearingClaw.java
+++ b/src/main/java/thePackmaster/cards/clawpack/SearingClaw.java
@@ -4,13 +4,10 @@ import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
-import com.megacrit.cardcrawl.actions.common.DamageAllEnemiesAction;
-import com.megacrit.cardcrawl.actions.watcher.PressEndTurnButtonAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.vfx.combat.ClawEffect;
-import thePackmaster.util.Wiz;
 
 import static thePackmaster.SpireAnniversary5Mod.CLAW;
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -28,7 +25,7 @@ public class SearingClaw extends AbstractClawCard {
 
     public void use(AbstractPlayer p, AbstractMonster m) {
 
-        for (int i = 0; i < timesUpgraded+1; i++) {
+        for (int i = 0; i < timesUpgraded + 1; i++) {
             this.addToBot(new VFXAction(new ClawEffect(m.hb.cX, m.hb.cY, Color.ORANGE, Color.WHITE), 0.2F));
         }
 
@@ -42,7 +39,7 @@ public class SearingClaw extends AbstractClawCard {
     @Override
     public void upgrade() {
         this.upgradeDamage(2 + this.timesUpgraded);
-        this.upgradeMagicNumber(1 + this.timesUpgraded/2);
+        this.upgradeMagicNumber(1 + this.timesUpgraded / 2);
         ++this.timesUpgraded;
         this.upgraded = true;
         this.name = cardStrings.NAME + "+" + this.timesUpgraded;
@@ -52,6 +49,7 @@ public class SearingClaw extends AbstractClawCard {
     public boolean canUpgrade() {
         return true;
     }
+
     public void upp() {
         //Unused
     }

--- a/src/main/java/thePackmaster/cards/contentcreatorpack/OlexasCloak.java
+++ b/src/main/java/thePackmaster/cards/contentcreatorpack/OlexasCloak.java
@@ -13,11 +13,9 @@ public class OlexasCloak extends AbstractContentCard {
     public final static String ID = makeID("OlexasCloak");
 
     public OlexasCloak() {
-        super(ID, -1, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
-        baseBlock = 18;
-        PersistFields.setBaseValue(this, 2);
+        super(ID, 1, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
+        baseBlock = 20;
         HoardField.setBaseValue(this, 3);
-        selfRetain = true;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/contentcreatorpack/OlexasCloak.java
+++ b/src/main/java/thePackmaster/cards/contentcreatorpack/OlexasCloak.java
@@ -1,7 +1,9 @@
 package thePackmaster.cards.contentcreatorpack;
 
 import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.PersistFields;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePackmaster.actions.dimensiongatepack.HoardPayoffAction;
 import thePackmaster.cards.AbstractPackmasterCard;
@@ -12,10 +14,13 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 public class OlexasCloak extends AbstractContentCard {
     public final static String ID = makeID("OlexasCloak");
 
+
     public OlexasCloak() {
         super(ID, 1, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
-        baseBlock = 20;
+        baseBlock = 18;
         HoardField.setBaseValue(this, 3);
+        selfRetain = true;
+        PersistFields.setBaseValue(this, 3);
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/dimensiongatepack/Inferno.java
+++ b/src/main/java/thePackmaster/cards/dimensiongatepack/Inferno.java
@@ -18,13 +18,11 @@ public class Inferno extends AbstractDimensionalCard {
     public final static String ID = makeID("Inferno");
 
     public Inferno() {
-        super(ID, -1, CardRarity.RARE, com.megacrit.cardcrawl.cards.AbstractCard.CardType.ATTACK, CardTarget.ALL_ENEMY);
+        super(ID, 1, CardRarity.RARE, com.megacrit.cardcrawl.cards.AbstractCard.CardType.ATTACK, CardTarget.ALL_ENEMY);
         baseDamage = 100;
         setFrame("infernoframe.png");
         isMultiDamage = true;
-        PersistFields.setBaseValue(this, 2);
         HoardField.setBaseValue(this, 8);
-        selfRetain = true;
     }
 
 

--- a/src/main/java/thePackmaster/cards/dimensiongatepack/Inferno.java
+++ b/src/main/java/thePackmaster/cards/dimensiongatepack/Inferno.java
@@ -23,6 +23,8 @@ public class Inferno extends AbstractDimensionalCard {
         setFrame("infernoframe.png");
         isMultiDamage = true;
         HoardField.setBaseValue(this, 8);
+        selfRetain = true;
+        PersistFields.setBaseValue(this, 3);
     }
 
 

--- a/src/main/java/thePackmaster/potions/clawpack/GenerateClawsPotion.java
+++ b/src/main/java/thePackmaster/potions/clawpack/GenerateClawsPotion.java
@@ -4,6 +4,7 @@ package thePackmaster.potions.clawpack;
 import basemod.abstracts.CustomPotion;
 import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction;
+import com.megacrit.cardcrawl.cards.blue.Claw;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.helpers.PowerTip;
@@ -36,7 +37,7 @@ public class GenerateClawsPotion extends CustomPotion {
 
     public void use(AbstractCreature target) {
         for (int i = 0; i < potency; i++) {
-            Wiz.atb(new MakeTempCardInHandAction(new GhostClaw()));
+            Wiz.atb(new MakeTempCardInHandAction(new Claw()));
         }
     }
 

--- a/src/main/java/thePackmaster/util/cardvars/HoardField.java
+++ b/src/main/java/thePackmaster/util/cardvars/HoardField.java
@@ -12,6 +12,7 @@ public class HoardField {
     public static SpireField<Integer> hoard = new SpireField<>(() -> -1);
     public static SpireField<Integer> baseHoard = new SpireField<>(() -> -1);
     public static SpireField<Boolean> isHoardUpgraded = new SpireField<>(() -> false);
+    public static SpireField<Boolean> isHoardModified = new SpireField<>(() -> false);
 
     public HoardField() {
     }
@@ -19,22 +20,34 @@ public class HoardField {
     public static void setBaseValue(AbstractCard card, int amount) {
         baseHoard.set(card, amount);
         hoard.set(card, amount);
-        card.initializeDescription();
     }
 
     public static void resetValueToBase(AbstractCard card) {
         HoardField.hoard.set(card, HoardField.baseHoard.get(card));
-        card.initializeDescription();
+        isHoardModified.set(card, false);
     }
 
     public static void upgrade(AbstractCard card, int amount) {
         isHoardUpgraded.set(card, true);
-        setBaseValue(card, (Integer)baseHoard.get(card) + amount);
-        card.initializeDescription();
+        baseHoard.set(card, baseHoard.get(card) + amount);
+        if (hoard.get(card) <= 0) {
+            //if for some reason hoard is not initialized right now, do it.
+            hoard.set(card, baseHoard.get(card));
+        } else {
+            //in-combat upgrades (armaments) should not reset the hoard counter, but drop it down in tandem with the change to base.
+            hoard.set(card, hoard.get(card) + amount);
+
+            //...to a minimum value of 1.
+            if (hoard.get(card) < 1) {
+                hoard.set(card, 1);
+            }
+        }
+
     }
 
     public static void decrement(AbstractCard card, int value) {
         hoard.set(card, hoard.get(card) - value);
-        card.initializeDescription();
+
+        isHoardModified.set(card, true);
     }
 }

--- a/src/main/java/thePackmaster/util/cardvars/HoardVar.java
+++ b/src/main/java/thePackmaster/util/cardvars/HoardVar.java
@@ -2,6 +2,7 @@ package thePackmaster.util.cardvars;
 
 import basemod.abstracts.DynamicVariable;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import thePackmaster.cards.AbstractPackmasterCard;
 
 public class HoardVar extends DynamicVariable {
     @Override
@@ -11,12 +12,11 @@ public class HoardVar extends DynamicVariable {
 
     @Override
     public boolean isModified(AbstractCard card) {
-        return HoardField.isHoardUpgraded.get(card);
+        return HoardField.isHoardModified.get(card);
     }
 
-    @Override
     public void setIsModified(AbstractCard card, boolean v) {
-        HoardField.isHoardUpgraded.set(card, v);
+        HoardField.isHoardModified.set(card, v);
     }
 
     @Override
@@ -26,7 +26,7 @@ public class HoardVar extends DynamicVariable {
 
     @Override
     public int baseValue(AbstractCard card) {
-        return HoardField.hoard.get(card);
+        return HoardField.baseHoard.get(card);
     }
 
     @Override

--- a/src/main/java/thePackmaster/util/cardvars/HoardVar.java
+++ b/src/main/java/thePackmaster/util/cardvars/HoardVar.java
@@ -1,7 +1,9 @@
 package thePackmaster.util.cardvars;
 
 import basemod.abstracts.DynamicVariable;
+import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.Settings;
 import thePackmaster.cards.AbstractPackmasterCard;
 
 public class HoardVar extends DynamicVariable {
@@ -32,5 +34,15 @@ public class HoardVar extends DynamicVariable {
     @Override
     public boolean upgraded(AbstractCard card) {
         return HoardField.isHoardUpgraded.get(card);
+    }
+
+    @Override
+    public Color getIncreasedValueColor() {
+        return Settings.RED_TEXT_COLOR;
+    }
+
+    @Override
+    public Color getDecreasedValueColor() {
+        return Settings.GREEN_TEXT_COLOR;
     }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/clawpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/clawpack/Keywordstrings.json
@@ -4,6 +4,6 @@
     "NAMES": [
       "sharpen"
     ],
-    "DESCRIPTION": "Raises the damage dealt by all existing #yClaws and any #yGhost #yClaws created this combat."
+    "DESCRIPTION": "Raises the damage dealt by all existing #yClaws."
   }
 ]

--- a/src/main/resources/anniv5Resources/localization/eng/clawpack/Potionstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/clawpack/Potionstrings.json
@@ -25,7 +25,7 @@
     "NAME": "Bottled Claws",
     "DESCRIPTIONS": [
       "Add #b",
-      " #yGhost #yClaws to your hand."
+      " #yClaws to your hand."
     ]
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/contentcreatorpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/contentcreatorpack/Cardstrings.json
@@ -1,7 +1,7 @@
 {
   "${ModID}:OlexasCloak": {
     "NAME": "Olexa's Cloak",
-    "DESCRIPTION": "${ModID}:Hoard !hoard!. NL Gain !B! Block."
+    "DESCRIPTION": "{@@}Retain. NL After !hoard! more {!hoard!|1= play|>1= plays}, gain !B! Block. NL stslib:Persist !stslib:persist!."
   },
   "${ModID}:HuttsGamble": {
     "NAME": "Hutts' Gamble",

--- a/src/main/resources/anniv5Resources/localization/eng/contentcreatorpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/contentcreatorpack/Cardstrings.json
@@ -1,7 +1,7 @@
 {
   "${ModID}:OlexasCloak": {
     "NAME": "Olexa's Cloak",
-    "DESCRIPTION": "Retain. NL ${ModID}:Hoard !hoard!: Gain !B! Block. NL stslib:Persist !stslib:persist! ."
+    "DESCRIPTION": "${ModID}:Hoard !hoard!. NL Gain !B! Block."
   },
   "${ModID}:HuttsGamble": {
     "NAME": "Hutts' Gamble",

--- a/src/main/resources/anniv5Resources/localization/eng/dimensiongatepack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/dimensiongatepack/Cardstrings.json
@@ -27,7 +27,7 @@
   },
   "${ModID}:Inferno": {
     "NAME": "Inferno",
-    "DESCRIPTION": "${ModID}:Hoard !hoard!. NL Deal !D! damage to ALL enemies."
+    "DESCRIPTION": "{@@}Retain. NL After !hoard! more {!hoard!|1= play|>1= plays}, Deal !D! damage to ALL enemies. NL stslib:Persist !stslib:persist!."
   },
   "${ModID}:LethalShot": {
     "NAME": "Lethal Shot",

--- a/src/main/resources/anniv5Resources/localization/eng/dimensiongatepack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/dimensiongatepack/Cardstrings.json
@@ -27,7 +27,7 @@
   },
   "${ModID}:Inferno": {
     "NAME": "Inferno",
-    "DESCRIPTION": "Retain. NL ${ModID}:Hoard !hoard!: Deal !D! damage to ALL enemies. NL stslib:Persist !stslib:persist! ."
+    "DESCRIPTION": "${ModID}:Hoard !hoard!. NL Deal !D! damage to ALL enemies."
   },
   "${ModID}:LethalShot": {
     "NAME": "Lethal Shot",

--- a/src/main/resources/anniv5Resources/localization/eng/dimensiongatepack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/dimensiongatepack/Keywordstrings.json
@@ -4,6 +4,6 @@
     "NAMES": [
       "hoard"
     ],
-    "DESCRIPTION": "When played, reduce Hoard by #bX (the card's cost). When Hoard reaches #b0, its effects trigger."
+    "DESCRIPTION": "When played, if this card's cost is greater than 0 and lower than it's Hoard: NL Reduce Hoard by the card's cost and ignore all other card effects. NL Return the card to your hand. NL The card #yRetains this turn."
   }
 ]


### PR DESCRIPTION
Claw Pack gutted... by making Ghost Claws not inherit Sharpen scaling.  Bumped up their damage by 1 and Sharpen by 1 so they match the original Claw card instead of being a weaker Claw, but yeah.  These are the main contributor to clawPack scaling too hard.  It should require some effort to scale up, and encourage proper use of Cardistry and other recursion effects and card draw rather than Claw Pack being completely self-sufficient.

Fixed the ClawUp method increasing base damage and flashing in red Claws that don't deal damage.

Alclawmize's generate claws potion now gives normal Claws instead of Ghost Claws.

Also simplified the Hoard keyword significantly, no more Persist or Retain, that effect is all baked into the Hoard keyword itself.  It now works with non-X cost cards, and both Olexa's Cloak and Inferno now cost 1.  (Kept the X-Cost functionality should someone else decide to use it).  Each play simply reduces the Hoard value by the card's cost (1 most of the time, but this way it isn't completely gutted by getting snecko'd).  The card can be repeated indefinitely to keep reducing the Hoard value until triggered.

Olexa Cloak - +2 Block.