### PR TITLE
Made Eternal Flame not use makeStatEquivalentCopy

### DIFF
--- a/src/main/java/thePackmaster/cards/cosmoscommandpack/EternalStrike.java
+++ b/src/main/java/thePackmaster/cards/cosmoscommandpack/EternalStrike.java
@@ -5,6 +5,9 @@ import com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thePackmaster.actions.upgradespack.SuperUpgradeAction;
+
+import java.util.*;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 import static thePackmaster.util.Wiz.atb;
@@ -23,8 +26,23 @@ public class EternalStrike extends AbstractCosmosCard {
     }
 
     public void triggerOnExhaust() {
-        AbstractCard copyOfThis = this.makeStatEquivalentCopy();
-        copyOfThis.damage = copyOfThis.baseDamage += magicNumber;
+        AbstractCard copyOfThis = this.makeCopy();
+
+        ArrayList<AbstractCard> cardList = new ArrayList<>();
+        cardList.add(copyOfThis);
+        if (timesUpgraded > 1)
+            atb(new SuperUpgradeAction(cardList, timesUpgraded));
+        else if (upgraded)
+            copyOfThis.upgrade();
+
+        atb(new AbstractGameAction() {
+            @Override
+            public void update() {
+                copyOfThis.damage = copyOfThis.baseDamage = baseDamage + magicNumber;
+                this.isDone = true;
+            }
+        });
+
         atb(new MakeTempCardInHandAction(copyOfThis));
     }
 


### PR DESCRIPTION
I had to add logic to account for if the card was upgraded, and for if it was upgraded more than once (e.g. via Masterwork)