### PR TITLE
Fix pack filtering and hat menus being positioned incorrectly at resolutions that aren't a 16:9 ratio

### DIFF
--- a/src/main/java/thePackmaster/SpireAnniversary5Mod.java
+++ b/src/main/java/thePackmaster/SpireAnniversary5Mod.java
@@ -2,7 +2,6 @@ package thePackmaster;
 
 import basemod.AutoAdd;
 import basemod.BaseMod;
-import basemod.ModLabeledToggleButton;
 import basemod.ModPanel;
 import basemod.abstracts.CustomSavable;
 import basemod.devcommands.ConsoleCommand;
@@ -91,6 +90,7 @@ import thePackmaster.stances.downfallpack.AncientStance;
 import thePackmaster.stances.sentinelpack.Angry;
 import thePackmaster.stances.sentinelpack.Serene;
 import thePackmaster.ui.CurrentRunCardsTopPanelItem;
+import thePackmaster.ui.FixedModLabeledToggleButton.FixedModLabeledToggleButton;
 import thePackmaster.ui.InfestTextIcon;
 import thePackmaster.ui.PackFilterMenu;
 import thePackmaster.util.JediUtil;
@@ -1047,7 +1047,7 @@ public class SpireAnniversary5Mod implements
         settingsPanel = new ModPanel();
         //int configStep = 40;
 
-        ModLabeledToggleButton allPacksModeBtn = new ModLabeledToggleButton(configStrings.TEXT[3], 350.0f, 600F, Settings.CREAM_COLOR, FontHelper.charDescFont, allPacksMode, settingsPanel, (label) -> {
+        FixedModLabeledToggleButton allPacksModeBtn = new FixedModLabeledToggleButton(configStrings.TEXT[3], 350.0f, 600F, Settings.CREAM_COLOR, FontHelper.charDescFont, allPacksMode, settingsPanel, (label) -> {
 
         }, (button) -> {
             allPacksMode = button.enabled;
@@ -1056,7 +1056,7 @@ public class SpireAnniversary5Mod implements
 
         settingsPanel.addUIElement(allPacksModeBtn);
 
-        ModLabeledToggleButton oneFrameModeBtn = new ModLabeledToggleButton(configStrings.TEXT[4], 350.0f, 400F, Settings.CREAM_COLOR, FontHelper.charDescFont, oneFrameMode, settingsPanel, (label) -> {
+        FixedModLabeledToggleButton oneFrameModeBtn = new FixedModLabeledToggleButton(configStrings.TEXT[4], 350.0f, 400F, Settings.CREAM_COLOR, FontHelper.charDescFont, oneFrameMode, settingsPanel, (label) -> {
 
         }, (button) -> {
             oneFrameMode = button.enabled;
@@ -1065,7 +1065,7 @@ public class SpireAnniversary5Mod implements
 
         settingsPanel.addUIElement(oneFrameModeBtn);
 
-        ModLabeledToggleButton sharedContentBtn = new ModLabeledToggleButton(configStrings.TEXT[5], 350.0f, 500F, Settings.CREAM_COLOR, FontHelper.charDescFont, sharedContentMode, settingsPanel, (label) -> {
+        FixedModLabeledToggleButton sharedContentBtn = new FixedModLabeledToggleButton(configStrings.TEXT[5], 350.0f, 500F, Settings.CREAM_COLOR, FontHelper.charDescFont, sharedContentMode, settingsPanel, (label) -> {
 
         }, (button) -> {
             sharedContentMode = button.enabled;

--- a/src/main/java/thePackmaster/hats/HatMenu.java
+++ b/src/main/java/thePackmaster/hats/HatMenu.java
@@ -1,6 +1,5 @@
 package thePackmaster.hats;
 
-import basemod.ModLabeledToggleButton;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -21,6 +20,7 @@ import thePackmaster.packs.AlignmentPack;
 import thePackmaster.packs.CoreSetPack;
 import thePackmaster.packs.PsychicPack;
 import thePackmaster.patches.DropdownColorsPatch;
+import thePackmaster.ui.FixedModLabeledToggleButton.FixedModLabeledToggleButton;
 import thePackmaster.util.Wiz;
 
 import java.io.IOException;
@@ -53,17 +53,18 @@ public class HatMenu {
     private static final TextureRegion MENU_BG = new TextureRegion(ImageMaster.loadImage("img/ModPanelBg.png"));
 
     //positions
-    private static final float BG_X_SCALE = Settings.scale * 0.275f;
-    private static final float BG_Y_SCALE = Settings.scale * 0.8f;
-    private static final float BG_X = 525f * Settings.scale;
-    private static final float BG_Y = Settings.HEIGHT - 40f * Settings.scale - MENU_BG.getRegionHeight() * BG_Y_SCALE;
+    private static final float BG_X_SCALE = Settings.xScale * 0.275f;
+    private static final float BG_Y_SCALE = Settings.yScale * 0.8f;
+    private static final float BG_X = 525f * Settings.xScale;
+    private static final float BG_Y = Settings.HEIGHT - 40f * Settings.yScale - MENU_BG.getRegionHeight() * BG_Y_SCALE;
     private static final float FLAVOR_X = BG_X + MENU_BG.getRegionWidth() * BG_X_SCALE * 0.5f;
-    private static final float DROPDOWN_X = 586f * Settings.scale;
-    private static final float DROPDOWN_Y = Settings.HEIGHT - 160f * Settings.scale;
-    private static final float PREVIEW_X = BG_X + (210 * Settings.scale);
-    private static final float PREVIEW_Y = BG_Y + (215 * Settings.scale);
-    private static final float CHECKBOX_X = BG_X + (100 * Settings.scale);
-    private static final float CHECKBOX_Y = BG_Y + (45 * Settings.scale);
+    private static final float DROPDOWN_X = 586f * Settings.xScale;
+    private static final float DROPDOWN_Y = Settings.HEIGHT - 160f * Settings.yScale;
+    private static final float PREVIEW_X = BG_X + (210 * Settings.xScale);
+    private static final float PREVIEW_Y = BG_Y + (215 * Settings.yScale);
+    // We pass these values to the button class, which does its own multiplication by xScale/yScale
+    private static final float CHECKBOX_X = BG_X / Settings.xScale + 100;
+    private static final float CHECKBOX_Y = BG_Y / Settings.yScale + 45;
 
     public static AbstractPlayer dummy;
 
@@ -71,7 +72,7 @@ public class HatMenu {
 
     public static int currentHatIndex;
 
-    private static final ModLabeledToggleButton rainbowButton = makeRainbowButton();
+    private static final FixedModLabeledToggleButton rainbowButton = makeRainbowButton();
     private static boolean showRainbowButton = false;
 
     private static final Color LOCKED_COLOR = Color.GRAY.cpy().mul(1f,1f,1f,0.95f);
@@ -83,9 +84,9 @@ public class HatMenu {
         refreshHatDropdown();
     }
 
-    private static ModLabeledToggleButton makeRainbowButton() {
+    private static FixedModLabeledToggleButton makeRainbowButton() {
         SpireAnniversary5Mod.isHatRainbow = SpireAnniversary5Mod.wasRainbowLastEnabled();
-        return new ModLabeledToggleButton(TEXT[11], CHECKBOX_X, CHECKBOX_Y, Color.WHITE, FontHelper.tipBodyFont, SpireAnniversary5Mod.isHatRainbow , null, (label) -> {
+        return new FixedModLabeledToggleButton(TEXT[11], CHECKBOX_X, CHECKBOX_Y, Color.WHITE, FontHelper.tipBodyFont, SpireAnniversary5Mod.isHatRainbow , null, (label) -> {
         },
                 (button) -> {
                     try {
@@ -326,7 +327,7 @@ public class HatMenu {
     public void render(SpriteBatch sb) {
         sb.draw(MENU_BG, BG_X, BG_Y, 0f, 0f, MENU_BG.getRegionWidth(), MENU_BG.getRegionHeight(), BG_X_SCALE, BG_Y_SCALE, 0f);
 
-        FontHelper.renderWrappedText(sb, FontHelper.panelNameFont, flavorText, FLAVOR_X, DROPDOWN_Y - (343 * Settings.scale), 330 * Settings.scale, Color.YELLOW.cpy(), 0.8F);
+        FontHelper.renderWrappedText(sb, FontHelper.panelNameFont, flavorText, FLAVOR_X, DROPDOWN_Y - (343 * Settings.yScale), 330 * Settings.xScale, Color.YELLOW.cpy(), 0.8F);
 
         getDummy().renderPlayerImage(sb);
 

--- a/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
+++ b/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
@@ -1,6 +1,5 @@
 package thePackmaster.patches;
 
-import basemod.ModLabeledButton;
 import basemod.ReflectionHacks;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -18,6 +17,7 @@ import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.ThePackmaster;
 import thePackmaster.hats.HatMenu;
 import thePackmaster.packs.AbstractCardPack;
+import thePackmaster.ui.FixedModLabeledToggleButton.FixedModLabeledButton;
 import thePackmaster.ui.PackFilterMenu;
 
 import java.io.IOException;
@@ -42,9 +42,9 @@ public class MainMenuUIPatch {
     public static final String RANDOM = "Random";
     public static final String CHOICE = "Choice";
 
-    private static final float CHECKBOX_X_OFF = 32.0f * Settings.scale;
+    private static final float CHECKBOX_X_OFF = 32.0f * Settings.xScale;
     private static final float CHECKBOX_X;
-    private static final float CHECKBOX_Y = Settings.HEIGHT / 2.0f - 175.0f * Settings.scale;
+    private static final float CHECKBOX_Y = Settings.HEIGHT / 2.0f - 175.0f * Settings.yScale;
 
     private static final int PACK_COUNT = SpireAnniversary5Mod.PACKS_PER_RUN;
     private static final int DROPDOWN_ROWCOUNT = 10;
@@ -53,19 +53,21 @@ public class MainMenuUIPatch {
     private static final float DROPDOWNS_START_Y = CHECKBOX_Y + DROPDOWNS_SPACING * (PACK_COUNT + 0.5f);
 
     //filter button fields
+    // We pass these values to the button class, which does its own multiplication by xScale/yScale
     private static final float FILTERBUTTON_X = 55f;
     private static final float FILTERBUTTON_Y = 1080f - 122f;
 
     private static final PackFilterMenu filterMenu = new PackFilterMenu();
-    private static final ModLabeledButton openFilterMenuButton;
+    private static final FixedModLabeledButton openFilterMenuButton;
     private static final HashMap<String, Integer> idToIndex = new HashMap<>();
 
     //hat button fields
+    // We pass these values to the button class, which does its own multiplication by xScale/yScale
     private static final float HATBUTTON_X = 610f;
     private static final float HATBUTTON_Y = 1080f - 122f;
 
     public static final HatMenu hatMenu = new HatMenu();
-    private static final ModLabeledButton openHatMenuButton;
+    private static final FixedModLabeledButton openHatMenuButton;
 
     static {
         options.add(TEXT[2]);
@@ -140,10 +142,10 @@ public class MainMenuUIPatch {
             CHECKBOX_X = DROPDOWN_X + CHECKBOX_X_OFF;
         }
 
-        openFilterMenuButton = new ModLabeledButton(uiStrings.TEXT[4], FILTERBUTTON_X, FILTERBUTTON_Y, null,
+        openFilterMenuButton = new FixedModLabeledButton(uiStrings.TEXT[4], FILTERBUTTON_X, FILTERBUTTON_Y, null,
                 (button) -> filterMenu.toggle());
 
-        openHatMenuButton = new ModLabeledButton(uiStrings.TEXT[5], HATBUTTON_X, HATBUTTON_Y, null, (button) -> hatMenu.toggle());
+        openHatMenuButton = new FixedModLabeledButton(uiStrings.TEXT[5], HATBUTTON_X, HATBUTTON_Y, null, (button) -> hatMenu.toggle());
     }
 
 

--- a/src/main/java/thePackmaster/ui/FixedModLabeledToggleButton/FixedModLabel.java
+++ b/src/main/java/thePackmaster/ui/FixedModLabeledToggleButton/FixedModLabel.java
@@ -1,0 +1,90 @@
+package thePackmaster.ui.FixedModLabeledToggleButton;
+
+import basemod.IUIElement;
+import basemod.ModPanel;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+
+import java.util.function.Consumer;
+
+// This class is a near-copy of the BaseMod class, changed to use Settings.xScale and Settings.yScale
+public class FixedModLabel implements IUIElement {
+    private Consumer<FixedModLabel> update;
+    
+    public ModPanel parent;
+    public String text;
+    public float x;
+    public float y;
+    public Color color;
+    public BitmapFont font;
+    
+    public FixedModLabel(String labelText, float xPos, float yPos, ModPanel p, Consumer<FixedModLabel> updateFunc) {
+    	this(labelText, xPos, yPos, Color.WHITE, FontHelper.buttonLabelFont, p, updateFunc);
+    }
+    
+    public FixedModLabel(String labelText, float xPos, float yPos, Color color, ModPanel p, Consumer<FixedModLabel> updateFunc) {
+    	this(labelText, xPos, yPos, color, FontHelper.buttonLabelFont, p, updateFunc);
+    }
+    
+    public FixedModLabel(String labelText, float xPos, float yPos, BitmapFont font, ModPanel p, Consumer<FixedModLabel> updateFunc) {
+    	this(labelText, xPos, yPos, Color.WHITE, font, p, updateFunc);
+    }
+    
+    public FixedModLabel(String labelText, float xPos, float yPos, Color color, BitmapFont font, ModPanel p, Consumer<FixedModLabel> updateFunc) {
+        text = labelText;
+        x = xPos*Settings.xScale;
+        y = yPos*Settings.yScale;
+        this.color = color;
+        this.font = font;
+        
+        parent = p;
+        update = updateFunc;
+    }
+    
+    public void render(SpriteBatch sb) {
+        FontHelper.renderFontLeftDownAligned(sb, this.font, text, x, y, this.color);
+    }
+    
+    public void update() {
+        update.accept(this);
+    }
+    
+	@Override
+	public int renderLayer() {
+		return ModPanel.TEXT_LAYER;
+	}
+
+	@Override
+	public int updateOrder() {
+		return ModPanel.PRIORITY_UPDATE;
+	}
+
+    @Override
+    public void set(float xPos, float yPos) {
+        x = xPos*Settings.xScale;
+        y = yPos*Settings.yScale;
+    }
+
+    @Override
+    public void setX(float xPos) {
+        x = xPos*Settings.xScale;
+    }
+
+    @Override
+    public void setY(float yPos) {
+        y = yPos*Settings.yScale;
+    }
+
+    @Override
+    public float getX() {
+        return x/Settings.xScale;
+    }
+
+    @Override
+    public float getY() {
+        return y/Settings.yScale;
+    }
+}

--- a/src/main/java/thePackmaster/ui/FixedModLabeledToggleButton/FixedModLabeledButton.java
+++ b/src/main/java/thePackmaster/ui/FixedModLabeledToggleButton/FixedModLabeledButton.java
@@ -16,6 +16,7 @@ import com.megacrit.cardcrawl.helpers.input.InputHelper;
 
 import java.util.function.Consumer;
 
+// This class is a near-copy of the BaseMod class, changed to use Settings.xScale and Settings.yScale
 public class FixedModLabeledButton implements IUIElement {
     private Consumer<FixedModLabeledButton> click;
     private Hitbox hb;

--- a/src/main/java/thePackmaster/ui/FixedModLabeledToggleButton/FixedModLabeledButton.java
+++ b/src/main/java/thePackmaster/ui/FixedModLabeledToggleButton/FixedModLabeledButton.java
@@ -1,0 +1,144 @@
+package thePackmaster.ui.FixedModLabeledToggleButton;
+
+import basemod.IUIElement;
+import basemod.ModPanel;
+import basemod.helpers.UIElementModificationHelper;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.helpers.input.InputHelper;
+
+import java.util.function.Consumer;
+
+public class FixedModLabeledButton implements IUIElement {
+    private Consumer<FixedModLabeledButton> click;
+    private Hitbox hb;
+    private float x;
+    private float y;
+    private float w;
+    private float middle_width;
+    private float h;
+
+    public BitmapFont font;
+    public String label;
+    public ModPanel parent;
+    public Color color, colorHover;
+
+    // this "sinks" the text to the sides - i.e. makes the middle part of button a bit shorter than the text width,
+    // looks a bit more balanced to the eye
+    private static final float TEXT_OFFSET = 9F;
+
+    private Texture textureLeft, textureRight, textureMiddle;
+
+    public FixedModLabeledButton(String label, float xPos, float yPos, ModPanel p, Consumer<FixedModLabeledButton> c) {
+        this(label, xPos, yPos, Color.WHITE, Color.GREEN, FontHelper.buttonLabelFont, p, c);
+    }
+
+    public FixedModLabeledButton(String label, float xPos, float yPos, Color textColor, Color textColorHover,
+                                 ModPanel p, Consumer<FixedModLabeledButton> c) {
+        this(label, xPos, yPos, textColor, textColorHover, FontHelper.buttonLabelFont, p, c);
+    }
+
+    public FixedModLabeledButton(String label, float xPos, float yPos, Color textColor, Color textColorHover,
+                                 BitmapFont font, ModPanel p, Consumer<FixedModLabeledButton> c) {
+        this.label = label;
+        this.font = font;
+        color = textColor;
+        colorHover = textColorHover;
+
+        textureLeft = ImageMaster.loadImage("img/ButtonLeft.png");
+        textureRight = ImageMaster.loadImage("img/ButtonRight.png");
+        textureMiddle = ImageMaster.loadImage("img/ButtonMiddle.png");
+
+        x = xPos * Settings.xScale;
+        y = yPos * Settings.yScale;
+
+        middle_width = Math.max(0, FontHelper.getSmartWidth(font, label, 9999f, 0f) - 2 * TEXT_OFFSET * Settings.xScale);
+        w = (this.textureLeft.getWidth() + this.textureRight.getWidth()) * Settings.xScale + middle_width;
+        h = this.textureLeft.getHeight() * Settings.yScale;
+        hb = new Hitbox(this.x + 1F * Settings.xScale, this.y + 1F * Settings.yScale, this.w - 2F * Settings.xScale, this.h - 2F * Settings.yScale);
+
+        parent = p;
+        click = c;
+    }
+
+    public void render(SpriteBatch sb) {
+
+        sb.draw(textureLeft, x, y, textureLeft.getWidth() * Settings.xScale, h);
+        sb.draw(textureMiddle, x + textureLeft.getWidth() * Settings.xScale, y, middle_width, h);
+        sb.draw(textureRight, x + textureLeft.getWidth() * Settings.xScale + middle_width, y,
+                textureRight.getWidth() * Settings.xScale, h);
+
+        hb.render(sb);
+
+        sb.setColor(Color.WHITE);
+        if (hb.hovered)
+            FontHelper.renderFontCentered(sb, font, label, hb.cX, hb.cY, colorHover );
+        else
+            FontHelper.renderFontCentered(sb, font, label, hb.cX, hb.cY, color);
+    }
+
+    public void update() {
+        hb.update();
+        if (hb.justHovered) {
+            CardCrawlGame.sound.playV("UI_HOVER", 0.75F);
+        }
+
+        if (hb.hovered && InputHelper.justClickedLeft) {
+            CardCrawlGame.sound.playA("UI_CLICK_1", -0.1F);
+            hb.clickStarted = true;
+        }
+
+        if (hb.clicked) {
+            hb.clicked = false;
+            onClick();
+        }
+
+    }
+
+    private void onClick() {
+        click.accept(this);
+    }
+
+    public int renderLayer() {
+        return 1;
+    }
+
+    public int updateOrder() {
+        return 1;
+    }
+
+    @Override
+    public void set(float xPos, float yPos) {
+        x = xPos*Settings.xScale;
+        y = yPos*Settings.yScale;
+
+        UIElementModificationHelper.moveHitboxByOriginalParameters(hb, x + 1F * Settings.xScale, y + 1F * Settings.yScale);
+    }
+
+    @Override
+    public void setX(float xPos) {
+        set(xPos, y/Settings.yScale);
+    }
+
+    @Override
+    public void setY(float yPos) {
+        set(x/Settings.xScale, yPos);
+    }
+
+    @Override
+    public float getX() {
+        return x/Settings.xScale;
+    }
+
+    @Override
+    public float getY() {
+        return y/Settings.yScale;
+    }
+}

--- a/src/main/java/thePackmaster/ui/FixedModLabeledToggleButton/FixedModLabeledToggleButton.java
+++ b/src/main/java/thePackmaster/ui/FixedModLabeledToggleButton/FixedModLabeledToggleButton.java
@@ -1,0 +1,101 @@
+package thePackmaster.ui.FixedModLabeledToggleButton;
+
+import basemod.IUIElement;
+import basemod.ModLabel;
+import basemod.ModPanel;
+import basemod.ModToggleButton;
+import basemod.patches.com.megacrit.cardcrawl.helpers.TipHelper.HeaderlessTip;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.input.InputHelper;
+
+import java.util.function.Consumer;
+
+// This class is a near-copy of the BaseMod class, changed to use Settings.xScale and Settings.yScale
+public class FixedModLabeledToggleButton implements IUIElement {
+	private static final float TEXT_X_OFFSET = 40.0f;
+	private static final float TEXT_Y_OFFSET = 8.0f;
+	
+	public FixedModToggleButton toggle;
+	public FixedModLabel text;
+	public String tooltip;
+	
+	public FixedModLabeledToggleButton(String labelText, float xPos, float yPos,
+									   Color color, BitmapFont font, boolean enabled, ModPanel p,
+									   Consumer<FixedModLabel> labelUpdate, Consumer<FixedModToggleButton> c) {
+		this(labelText, null, xPos, yPos, color, font, enabled, p, labelUpdate, c);
+	}
+
+	public FixedModLabeledToggleButton(String labelText, String tooltipText, float xPos, float yPos,
+									   Color color, BitmapFont font, boolean enabled, ModPanel p,
+									   Consumer<FixedModLabel> labelUpdate, Consumer<FixedModToggleButton> c) {
+		toggle = new FixedModToggleButton(xPos, yPos, enabled, false, p, c);
+		text = new FixedModLabel(labelText, xPos + TEXT_X_OFFSET, yPos + TEXT_Y_OFFSET,
+				color, font, p, labelUpdate);
+		tooltip = tooltipText;
+		
+		// TODO: implement multi-line text
+		toggle.wrapHitboxToText(labelText, 1000.0f, 0.0f, font);
+	}
+	
+	
+	@Override
+	public void render(SpriteBatch sb) {
+		toggle.render(sb);
+		text.render(sb);
+
+		if (tooltip != null && toggle.hb.hovered) {
+			HeaderlessTip.renderHeaderlessTip(
+					InputHelper.mX + 60f * Settings.xScale,
+					InputHelper.mY - 50f * Settings.yScale,
+					tooltip
+			);
+		}
+	}
+
+	@Override
+	public void update() {
+		toggle.update();
+		text.update();
+	}
+
+	@Override
+	public int renderLayer() {
+		return ModPanel.MIDDLE_LAYER;
+	}
+
+	@Override
+	public int updateOrder() {
+		return ModPanel.DEFAULT_UPDATE;
+	}
+
+	@Override
+	public void set(float xPos, float yPos) {
+		toggle.set(xPos, yPos);
+		text.set(xPos + TEXT_X_OFFSET, yPos + TEXT_Y_OFFSET);
+	}
+
+	@Override
+	public void setX(float xPos) {
+		toggle.setX(xPos);
+		text.setX(xPos + TEXT_X_OFFSET);
+	}
+
+	@Override
+	public void setY(float yPos) {
+		toggle.setY(yPos);
+		text.setY(yPos + TEXT_Y_OFFSET);
+	}
+
+	@Override
+	public float getX() {
+		return toggle.getX();
+	}
+
+	@Override
+	public float getY() {
+		return toggle.getY();
+	}
+}

--- a/src/main/java/thePackmaster/ui/FixedModLabeledToggleButton/FixedModToggleButton.java
+++ b/src/main/java/thePackmaster/ui/FixedModLabeledToggleButton/FixedModToggleButton.java
@@ -1,0 +1,150 @@
+package thePackmaster.ui.FixedModLabeledToggleButton;
+
+import basemod.IUIElement;
+import basemod.ModPanel;
+import basemod.helpers.UIElementModificationHelper;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.helpers.input.InputHelper;
+
+import java.util.function.Consumer;
+
+// This class is a near-copy of the BaseMod class, changed to use Settings.xScale and Settings.yScale
+public class FixedModToggleButton implements IUIElement {
+	private static final float TOGGLE_Y_DELTA = 0f;
+	private static final float TOGGLE_X_EXTEND = 12.0f;
+	private static final float HB_WIDTH_EXTENDED = 200.0f;
+	
+	private Consumer<FixedModToggleButton> toggle;
+	Hitbox hb;
+	private float x;
+	private float y;
+	private float w;
+	private float h;
+	private boolean extendedHitbox;
+	
+	public boolean enabled;
+	public ModPanel parent;
+
+	public FixedModToggleButton(float xPos, float yPos, ModPanel p, Consumer<FixedModToggleButton> c) {
+		this(xPos, yPos, false, true, p, c);
+	}
+	
+	public FixedModToggleButton(float xPos, float yPos, boolean enabled, boolean extendedHitbox, ModPanel p, Consumer<FixedModToggleButton> c) {
+		x = xPos * Settings.xScale;
+		y = yPos * Settings.yScale;
+		w = ImageMaster.OPTION_TOGGLE.getWidth();
+		h = ImageMaster.OPTION_TOGGLE.getHeight();
+		this.extendedHitbox = extendedHitbox;
+		if (extendedHitbox) {
+			hb = new Hitbox(x - TOGGLE_X_EXTEND * Settings.xScale,
+					y - TOGGLE_Y_DELTA * Settings.yScale,
+					HB_WIDTH_EXTENDED * Settings.xScale, h * Settings.yScale);
+		} else {
+			hb = new Hitbox(x, y - TOGGLE_Y_DELTA * Settings.yScale,
+					w * Settings.xScale, h * Settings.yScale);
+		}
+
+		this.enabled = enabled;
+		parent = p;
+		toggle = c;
+	}
+	
+	public void wrapHitboxToText(String text, float lineWidth, float lineSpacing, BitmapFont font) {
+		float tWidth = FontHelper.getSmartWidth(font, text, lineWidth, lineSpacing);
+		hb.width = tWidth + h * Settings.xScale + TOGGLE_X_EXTEND;
+	}
+	
+	public void render(SpriteBatch sb) {
+        if (this.hb.hovered) {
+            sb.setColor(Color.CYAN);
+        } else if (this.enabled) {
+            sb.setColor(Color.LIGHT_GRAY);
+        } else {
+            sb.setColor(Color.WHITE);
+        }
+        sb.draw(ImageMaster.OPTION_TOGGLE, x, y, w*Settings.xScale, h*Settings.yScale);
+        if (this.enabled) {
+            sb.setColor(Color.WHITE);
+            sb.draw(ImageMaster.OPTION_TOGGLE_ON, x, y, w*Settings.xScale, h*Settings.yScale);
+        }
+        this.hb.render(sb);
+	}
+	
+	public void update() {
+		hb.update();
+		
+		if (hb.justHovered) {
+			CardCrawlGame.sound.playV("UI_HOVER", 0.75f);
+		}
+		
+		if (hb.hovered) {
+            if (InputHelper.justClickedLeft) {
+                CardCrawlGame.sound.playA("UI_CLICK_1", -0.1f);
+                hb.clickStarted = true;
+            }
+		}
+		
+        if (hb.clicked) {
+            hb.clicked = false;
+            onToggle();
+        }
+	}
+	
+	private void onToggle() {
+		this.enabled = !enabled;
+		toggle.accept(this);
+	}
+
+	public void toggle() {
+		onToggle();
+	}
+	
+	@Override
+	public int renderLayer() {
+		return ModPanel.MIDDLE_LAYER;
+	}
+
+	@Override
+	public int updateOrder() {
+		return ModPanel.DEFAULT_UPDATE;
+	}
+
+	@Override
+	public void set(float xPos, float yPos) {
+		x = xPos*Settings.xScale;
+		y = yPos*Settings.yScale;
+
+		if (extendedHitbox) {
+			UIElementModificationHelper.moveHitboxByOriginalParameters(hb, x - TOGGLE_X_EXTEND * Settings.xScale,  y - TOGGLE_Y_DELTA * Settings.yScale);
+		} else {
+			UIElementModificationHelper.moveHitboxByOriginalParameters(hb, x, y - TOGGLE_Y_DELTA * Settings.yScale);
+		}
+	}
+
+	@Override
+	public void setX(float xPos) {
+		set(xPos, y/Settings.yScale);
+	}
+
+	@Override
+	public void setY(float yPos) {
+		set(x/Settings.xScale, yPos);
+	}
+
+	@Override
+	public float getX() {
+		return x/Settings.yScale;
+	}
+
+	@Override
+	public float getY() {
+		return y/Settings.xScale;
+	}
+}

--- a/src/main/java/thePackmaster/ui/PackFilterMenu.java
+++ b/src/main/java/thePackmaster/ui/PackFilterMenu.java
@@ -37,16 +37,18 @@ public class PackFilterMenu {
     private static final TextureRegion MENU_BG = new TextureRegion(ImageMaster.loadImage("img/ModPanelBg.png"));
 
     //positions
-    private static final float BG_X_SCALE = Settings.scale * 0.31f;
-    private static final float BG_Y_SCALE = Settings.scale * 0.8f;
-    private static final float BG_X = 25f * Settings.scale;
-    private static final float BG_Y = Settings.HEIGHT - 40f * Settings.scale - MENU_BG.getRegionHeight() * BG_Y_SCALE;
-    private static final float DROPDOWN_X = 90f * Settings.scale;
-    private static final float DROPDOWN_Y = Settings.HEIGHT - 160f * Settings.scale;
-    private static final float CHECKBOX_X = 150f;
-    private static final float CHECKBOX_Y = 490f;
-    private static final float PREVIEW_X = 235f * Settings.scale;
-    private static final float PREVIEW_Y = 700f * Settings.scale;
+    private static final float BG_X_SCALE = Settings.xScale * 0.31f;
+    private static final float BG_Y_SCALE = Settings.yScale * 0.8f;
+    private static final float BG_X = 25f * Settings.xScale;
+    private static final float BG_Y = Settings.HEIGHT - 40f * Settings.yScale - MENU_BG.getRegionHeight() * BG_Y_SCALE;
+    private static final float DROPDOWN_X = 90f * Settings.xScale;
+    private static final float DROPDOWN_Y = Settings.HEIGHT - 160f * Settings.yScale;
+    // ModLabeledToggleButton multiplies by Settings.scale itself... which isn't really correct, since it should be
+    // multiplying by xScale/yScale. We do our own manipulation ahead of time to cancel it out.
+    private static final float CHECKBOX_X = 150f * (Settings.xScale / Settings.scale);
+    private static final float CHECKBOX_Y = 490f * (Settings.yScale / Settings.scale);
+    private static final float PREVIEW_X = 235f * Settings.xScale;
+    private static final float PREVIEW_Y = 700f * Settings.yScale;
 
     private static final Color DISABLED_COLOR = Settings.RED_TEXT_COLOR.cpy();
 

--- a/src/main/java/thePackmaster/ui/PackFilterMenu.java
+++ b/src/main/java/thePackmaster/ui/PackFilterMenu.java
@@ -1,6 +1,5 @@
 package thePackmaster.ui;
 
-import basemod.ModLabeledToggleButton;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -16,6 +15,7 @@ import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.packs.AbstractCardPack;
 import thePackmaster.patches.DropdownColorsPatch;
 import thePackmaster.patches.MainMenuUIPatch;
+import thePackmaster.ui.FixedModLabeledToggleButton.FixedModLabeledToggleButton;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,7 +29,7 @@ public class PackFilterMenu {
     private final DropdownMenu dropdown;
     private AbstractCardPack viewedPack;
     private AbstractCard previewCard;
-    private ModLabeledToggleButton checkbox;
+    private FixedModLabeledToggleButton checkbox;
     private final ArrayList<AbstractCardPack> packs = new ArrayList<>();
 
 
@@ -43,10 +43,8 @@ public class PackFilterMenu {
     private static final float BG_Y = Settings.HEIGHT - 40f * Settings.yScale - MENU_BG.getRegionHeight() * BG_Y_SCALE;
     private static final float DROPDOWN_X = 90f * Settings.xScale;
     private static final float DROPDOWN_Y = Settings.HEIGHT - 160f * Settings.yScale;
-    // ModLabeledToggleButton multiplies by Settings.scale itself... which isn't really correct, since it should be
-    // multiplying by xScale/yScale. We do our own manipulation ahead of time to cancel it out.
-    private static final float CHECKBOX_X = 150f * (Settings.xScale / Settings.scale);
-    private static final float CHECKBOX_Y = 490f * (Settings.yScale / Settings.scale);
+    private static final float CHECKBOX_X = 150f;
+    private static final float CHECKBOX_Y = 490f;
     private static final float PREVIEW_X = 235f * Settings.xScale;
     private static final float PREVIEW_Y = 700f * Settings.yScale;
 
@@ -65,7 +63,7 @@ public class PackFilterMenu {
                 optionNames, FontHelper.tipBodyFont, Settings.CREAM_COLOR);
         DropdownColorsPatch.DropdownRowToColor.function.set(dropdown, (index) -> getFilterConfig(packs.get(index).packID) ? null : DISABLED_COLOR);
 
-        checkbox = new ModLabeledToggleButton(TEXT[0], CHECKBOX_X, CHECKBOX_Y, Color.WHITE, FontHelper.tipBodyFont, true, null, (label) -> {
+        checkbox = new FixedModLabeledToggleButton(TEXT[0], CHECKBOX_X, CHECKBOX_Y, Color.WHITE, FontHelper.tipBodyFont, true, null, (label) -> {
         },
                 (button) -> clickCheckmark(button.enabled));
 


### PR DESCRIPTION
Not sure why this wasn't fixed yet, but I assume it must be because people aren't aware that Settings.xScale and Settings.yScale exist and are different from Settings.scale. Those are what you need to use if you want things to work at ratios other than the game's base 16:9... but even the buttons provided by BaseMod don't use them. I bet there are mods out there with weird looking config panels on non-standard resolution ratios (the Packmaster config menu had things positioned wrong because of this).

To show that this works, here's how it looks at 1280x1024 (a resolution that's "taller" than normal), at 1680x720 (a resolution that's "wider" than normal), and 1280x720 (a resolution that's 16:9 but smaller than the base 1920x1080):

![image](https://user-images.githubusercontent.com/62083413/216817454-4b5aa35e-7e1c-47d0-acb3-c72f0e99c97c.png)
![image](https://user-images.githubusercontent.com/62083413/216817458-486bc8b2-e7b1-451f-ac24-60b598787b94.png)
![image](https://user-images.githubusercontent.com/62083413/216817462-33f2c647-3e66-4806-8c2e-ab328b6ad13c.png)

As you can see, some UI elements get stretched in slightly odd ways, and the UI isn't smart enough to compensate for the character image staying the same size while other stuff changes, but there's no major issues. These three test resolutions cover a pretty broad set of cases (wide/tall/normal), so this is probably enough to solve the issues people have been complaining about.

Leaving this one up for you to review since it's worth spreading the word about Settings.xScale and Settings.yScale and making sure any future UI code uses them, particularly when it comes to positioning. There are valid uses of Settings.scale (mostly for having a UI element scale up or down but keep its width-to-height ratio the same regardless of resolution), but positioning usually needs xScale/yScale to be correct.