### PR TITLE
Relic stats, run history, and a few bug fixes

### DIFF
--- a/src/main/java/thePackmaster/events/BlackMarketDealerEvent.java
+++ b/src/main/java/thePackmaster/events/BlackMarketDealerEvent.java
@@ -171,12 +171,14 @@ public class BlackMarketDealerEvent extends PhasedEvent {
 
 
                 .addOption(new TextPhase.OptionInfo(hasCollection() ? OPTIONS[23] : hasEnoughGoldForBuyCollection() ? OPTIONS[15] + getGoldCostForBuyCollection() + OPTIONS[16] : OPTIONS[9] + getGoldCostForBuyCollection() + OPTIONS[7], new PMCollection()).enabledCondition(this::canBuyCollection), (i) -> {   //PM Collection
+                    AbstractDungeon.player.loseGold(getGoldCostForBuyCollection());
                     AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, new PMCollection());
                     AbstractDungeon.shopRelicPool.remove(PMCollection.ID);
                     transitionKey("relicCollectionEnd");
                 })
 
                 .addOption(new TextPhase.OptionInfo(hasDecree() ? OPTIONS[23] : hasEnoughGoldForBuyDecree() ? OPTIONS[17] + getGoldCostForBuyDecree() + OPTIONS[18] : OPTIONS[9] + getGoldCostForBuyDecree() + OPTIONS[7], new BanishingDecree()).enabledCondition(this::canBuyDecree), (i) -> {   //Banishing Decree
+                    AbstractDungeon.player.loseGold(getGoldCostForBuyDecree());
                     AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, new BanishingDecree());
                     AbstractDungeon.shopRelicPool.remove(BanishingDecree.ID);
                     transitionKey("relicBanishingEnd");

--- a/src/main/java/thePackmaster/events/BlackMarketDealerEvent.java
+++ b/src/main/java/thePackmaster/events/BlackMarketDealerEvent.java
@@ -5,13 +5,13 @@ import basemod.abstracts.events.phases.TextPhase;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.cards.curses.CurseOfTheBell;
-import com.megacrit.cardcrawl.cards.curses.Necronomicurse;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.events.city.Beggar;
 import com.megacrit.cardcrawl.events.city.TheLibrary;
 import com.megacrit.cardcrawl.localization.EventStrings;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.rewards.RewardItem;
 import com.megacrit.cardcrawl.vfx.RainingGoldEffect;
 import com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect;
@@ -26,6 +26,8 @@ import thePackmaster.relics.BanishingDecree;
 import thePackmaster.relics.PMCollection;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
 
 import static thePackmaster.SpireAnniversary5Mod.*;
@@ -39,6 +41,7 @@ public class BlackMarketDealerEvent extends PhasedEvent {
     private int choice = 0;
 
     private int chosenDailyMarket;
+    private AbstractCard cardRemoved;
 
     public BlackMarketDealerEvent() {
         super(NAME, eventStrings.NAME, SpireAnniversary5Mod.makeImagePath("events/blackMarket.png"));
@@ -63,19 +66,21 @@ public class BlackMarketDealerEvent extends PhasedEvent {
                     @Override
                     public void update() {
                         if (!AbstractDungeon.isScreenUp && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
+                            AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
+                            AbstractCard c2 = null;
                             if (forRemoval) {
-                                AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
                                 AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(c, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
                                 AbstractDungeon.player.masterDeck.removeCard(c);
+                                cardRemoved = c;
                             } else {
-                                AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
                                 AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(c, (float) Settings.WIDTH * .33F, (float) Settings.HEIGHT / 2.0F));
                                 if (choice == 2) {
-                                    c = AbstractDungeon.gridSelectScreen.selectedCards.get(1);
-                                    AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(c, (float) Settings.WIDTH * .66F, (float) Settings.HEIGHT / 2.0F));
+                                    c2 = AbstractDungeon.gridSelectScreen.selectedCards.get(1);
+                                    AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(c2, (float) Settings.WIDTH * .66F, (float) Settings.HEIGHT / 2.0F));
                                 }
                                 if (choice == 0) {
                                     AbstractDungeon.player.loseGold(getGoldCostForBuy());
+                                    logMetric(ID, "Buy", Collections.singletonList(c.cardID), null, null, null, null, null, null, 0, 0, 0, 0, 0, getGoldCostForBuy());
                                     transitionKey("cardBuyEnd");
                                 }
                             }
@@ -87,11 +92,13 @@ public class BlackMarketDealerEvent extends PhasedEvent {
                                     forRemoval = false;
                                     AbstractDungeon.gridSelectScreen.open(getCardsForLibraryEffect(), 2, TheLibrary.OPTIONS[4], false, false, false, false);
                                 } else {
+                                    logMetric(ID, "Trade", Arrays.asList(c.cardID, c2.cardID), Collections.singletonList(cardRemoved.cardID), null, null, null, null, null, 0, 0, 0, 0, 0, 0);
                                     transitionKey("cardTradeEnd");
                                 }
                             } else if (choice == 1) {
                                 AbstractDungeon.effectList.add(new RainingGoldEffect(getGoldGainForSell()));
                                 AbstractDungeon.player.gainGold(getGoldGainForSell());
+                                logMetric(ID, "Sell", null, Collections.singletonList(c.cardID), null, null, null, null, null, 0, 0, 0, 0, getGoldGainForSell(), 0);
                                 transitionKey("cardSellEnd");
                             }
                         }
@@ -116,7 +123,7 @@ public class BlackMarketDealerEvent extends PhasedEvent {
                             AbstractDungeon.gridSelectScreen.open(getCardsForDraftedPurge(), 1, Beggar.OPTIONS[6], false, false, false, true);
 
                         })
-                        .addOption(OPTIONS[3], (t) -> this.openMap())
+                        .addOption(OPTIONS[3], (t) -> this.ignoreAndLeave())
         );
 
         registerPhase("cardBuyEnd", new TextPhase(DESCRIPTIONS[4]).addOption(OPTIONS[3], (t) -> this.openMap()));
@@ -134,6 +141,7 @@ public class BlackMarketDealerEvent extends PhasedEvent {
 
                             AbstractDungeon.gridSelectScreen.selectedCards.clear();
 
+                            logMetricRemoveCards(ID, "Cleanse", Collections.singletonList(c.cardID));
                             transitionKey("magicCleanseEnd");
 
                         }
@@ -144,6 +152,7 @@ public class BlackMarketDealerEvent extends PhasedEvent {
                             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new CurseOfTheBell(), (Settings.WIDTH * .33F), (float) (Settings.HEIGHT / 2)));
                             //AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new CurseOfTheBell(), (Settings.WIDTH * .75F), (float) (Settings.HEIGHT / 2)));
                             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new ConjurePack(), (Settings.WIDTH * .66F), (float) (Settings.HEIGHT / 2)));
+                            logMetricObtainCards(ID, "Conjure Pack", Arrays.asList(ConjurePack.ID, CurseOfTheBell.ID));
                             transitionKey("magicLearnEnd");
                         }).addOption(OPTIONS[12], (i) -> {   //Pack in a Jar Potion
                             AbstractDungeon.getCurrRoom().rewards.clear();
@@ -151,6 +160,7 @@ public class BlackMarketDealerEvent extends PhasedEvent {
                             skipDefaultCardRewards = true;
                             AbstractDungeon.combatRewardScreen.open();
                             skipDefaultCardRewards = false;
+                            logMetric(ID, "Pack in a Jar", null, null, null, null, null, Collections.singletonList(PackInAJar.POTION_ID), null, 0, 0, 0, 0, 0, 0);
                             transitionKey("magicSampleEnd");
                         })  //Remove a card.
                         .addOption(new TextPhase.OptionInfo(canRemoveCardsForCleanse() ? OPTIONS[13] : OPTIONS[14]).enabledCondition(this::canRemoveCardsForCleanse), (i) -> {   //Cleansing Ritual
@@ -158,7 +168,7 @@ public class BlackMarketDealerEvent extends PhasedEvent {
                             AbstractDungeon.gridSelectScreen.open(AbstractDungeon.player.masterDeck.getPurgeableCards(), 1, Beggar.OPTIONS[6], false, false, false, true);
 
                         })
-                        .addOption(OPTIONS[3], (t) -> this.openMap())
+                        .addOption(OPTIONS[3], (t) -> this.ignoreAndLeave())
         );
 
 
@@ -172,15 +182,19 @@ public class BlackMarketDealerEvent extends PhasedEvent {
 
                 .addOption(new TextPhase.OptionInfo(hasCollection() ? OPTIONS[23] : hasEnoughGoldForBuyCollection() ? OPTIONS[15] + getGoldCostForBuyCollection() + OPTIONS[16] : OPTIONS[9] + getGoldCostForBuyCollection() + OPTIONS[7], new PMCollection()).enabledCondition(this::canBuyCollection), (i) -> {   //PM Collection
                     AbstractDungeon.player.loseGold(getGoldCostForBuyCollection());
-                    AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, new PMCollection());
+                    AbstractRelic relic = new PMCollection();
+                    AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, relic);
                     AbstractDungeon.shopRelicPool.remove(PMCollection.ID);
+                    logMetricObtainRelicAtCost(ID, "PM Collection", relic, getGoldCostForBuyCollection());
                     transitionKey("relicCollectionEnd");
                 })
 
                 .addOption(new TextPhase.OptionInfo(hasDecree() ? OPTIONS[23] : hasEnoughGoldForBuyDecree() ? OPTIONS[17] + getGoldCostForBuyDecree() + OPTIONS[18] : OPTIONS[9] + getGoldCostForBuyDecree() + OPTIONS[7], new BanishingDecree()).enabledCondition(this::canBuyDecree), (i) -> {   //Banishing Decree
                     AbstractDungeon.player.loseGold(getGoldCostForBuyDecree());
-                    AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, new BanishingDecree());
+                    AbstractRelic relic = new BanishingDecree();
+                    AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, relic);
                     AbstractDungeon.shopRelicPool.remove(BanishingDecree.ID);
+                    logMetricObtainRelicAtCost(ID, "Banishing Decree", relic, getGoldCostForBuyDecree());
                     transitionKey("relicBanishingEnd");
                 })
 
@@ -189,10 +203,11 @@ public class BlackMarketDealerEvent extends PhasedEvent {
                     AbstractDungeon.player.gainGold(getGoldGainForSellHat());
                     Hats.addHat(true, CoreSetPack.ID);
                     Hats.currentHat = CoreSetPack.ID;
+                    logMetricGainGold(ID, "Sell Hat", getGoldGainForSellHat());
                     transitionKey("relicSellHatEnd");
                 })
 
-                .addOption(OPTIONS[3], (t) -> this.openMap())
+                .addOption(OPTIONS[3], (t) -> this.ignoreAndLeave())
         );
 
 
@@ -204,6 +219,10 @@ public class BlackMarketDealerEvent extends PhasedEvent {
         transitionKey("base");
     }
 
+    private void ignoreAndLeave() {
+        logMetricIgnored(ID);
+        this.openMap();
+    }
 
     private boolean hasEnoughGoldForBuyCard() {
         return AbstractDungeon.player.gold >= getGoldCostForBuy();

--- a/src/main/java/thePackmaster/patches/DisableRelicStatsForChinesePatch.java
+++ b/src/main/java/thePackmaster/patches/DisableRelicStatsForChinesePatch.java
@@ -1,0 +1,20 @@
+package thePackmaster.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireReturn;
+import com.megacrit.cardcrawl.core.Settings;
+import thePackmaster.SpireAnniversary5Mod;
+
+// This exists because relic stats were added after the mod was translated to Chinese (ZHS), so the entries in the
+// relic description array that relic stats expects aren't there
+@SpirePatch(cls = "relicstats.RelicStats", method = "registerCustomStats", optional = true)
+public class DisableRelicStatsForChinesePatch {
+    @SpirePrefixPatch
+    public static SpireReturn<Void> disableRelicStatsForChinese(String relicId, Object hasCustomStats) {
+        if (Settings.language == Settings.GameLanguage.ZHS && relicId.startsWith(SpireAnniversary5Mod.modID + ":")) {
+            return SpireReturn.Return();
+        }
+        return SpireReturn.Continue();
+    }
+}

--- a/src/main/java/thePackmaster/patches/GetEventNamePatch.java
+++ b/src/main/java/thePackmaster/patches/GetEventNamePatch.java
@@ -1,0 +1,23 @@
+package thePackmaster.patches;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireReturn;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.helpers.EventHelper;
+import thePackmaster.SpireAnniversary5Mod;
+
+@SpirePatch(
+        clz = EventHelper.class,
+        method = "getEventName",
+        paramtypez = String.class
+)
+public class GetEventNamePatch {
+    @SpirePrefixPatch
+    public static SpireReturn<String> GetEventName(String eventID) {
+        if (eventID != null && eventID.startsWith(SpireAnniversary5Mod.modID + ":")) {
+            return SpireReturn.Return(CardCrawlGame.languagePack.getEventString(eventID).NAME);
+        }
+        return SpireReturn.Continue();
+    }
+}

--- a/src/main/java/thePackmaster/patches/PMBoosterBoxPatch.java
+++ b/src/main/java/thePackmaster/patches/PMBoosterBoxPatch.java
@@ -17,6 +17,7 @@ public class PMBoosterBoxPatch {
         public static void addRewards(AbstractRoom __instance) {
             if (AbstractDungeon.player.hasRelic(PMBoosterBox.ID)) {
                 AbstractDungeon.getCurrRoom().rewards.add(new PMBoosterBoxCardReward());
+                PMBoosterBox.incrementRewards();
             }
         }
 

--- a/src/main/java/thePackmaster/patches/PacksRunHistoryPatch.java
+++ b/src/main/java/thePackmaster/patches/PacksRunHistoryPatch.java
@@ -1,0 +1,87 @@
+package thePackmaster.patches;
+
+import basemod.ReflectionHacks;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.evacipated.cardcrawl.modthespire.patcher.PatchingException;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.metrics.Metrics;
+import com.megacrit.cardcrawl.monsters.MonsterGroup;
+import com.megacrit.cardcrawl.screens.runHistory.RunHistoryScreen;
+import com.megacrit.cardcrawl.screens.stats.RunData;
+import javassist.*;
+import thePackmaster.SpireAnniversary5Mod;
+import thePackmaster.ThePackmaster;
+import thePackmaster.packs.AbstractCardPack;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PacksRunHistoryPatch {
+    private static final String[] TEXT = CardCrawlGame.languagePack.getUIString(SpireAnniversary5Mod.makeID("RunHistory")).TEXT;
+
+    @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
+    public static class PacksField {
+        @SpireRawPatch
+        public static void addPacks(CtBehavior ctBehavior) throws NotFoundException, CannotCompileException {
+            CtClass runData = ctBehavior.getDeclaringClass().getClassPool().get(RunData.class.getName());
+
+            String fieldSource = "public java.util.List packmaster_packs;";
+
+            CtField field = CtField.make(fieldSource, runData);
+
+            runData.addField(field);
+        }
+    }
+
+    @SpirePatch(clz = Metrics.class, method = "gatherAllData")
+    public static class GatherAllDataPatch {
+        @SpirePostfixPatch
+        public static void gatherAllDataPatch(Metrics __instance, boolean death, boolean trueVictor, MonsterGroup monsters) {
+            if (AbstractDungeon.player.chosenClass.equals(ThePackmaster.Enums.THE_PACKMASTER)) {
+                ReflectionHacks.privateMethod(Metrics.class, "addData", Object.class, Object.class)
+                        .invoke(__instance, "packmaster_packs", SpireAnniversary5Mod.currentPoolPacks.stream().map(p -> p.packID).collect(Collectors.toList()));
+            }
+        }
+    }
+
+    @SpirePatch(clz = RunHistoryScreen.class, method = "renderRunHistoryScreen")
+    public static class DisplayPacks {
+        @SuppressWarnings({"unchecked"})
+        @SpireInsertPatch(locator = Locator.class, localvars = { "header2x", "yOffset"})
+        public static void displayPacks(RunHistoryScreen __instance, SpriteBatch sb, float header2x, @ByRef float[] yOffset) throws NoSuchFieldException, IllegalAccessException {
+            RunData runData = ReflectionHacks.getPrivate(__instance, RunHistoryScreen.class, "viewedRun");
+            if (!runData.character_chosen.equals(ThePackmaster.Enums.THE_PACKMASTER.name())) {
+                return;
+            }
+
+            Field field = runData.getClass().getField("packmaster_packs");
+            List<String> packmaster_packs = (List<String>)field.get(runData);
+            if (packmaster_packs == null || packmaster_packs.isEmpty()) {
+                return;
+            }
+
+            String headerText = TEXT[0];
+            List<String> packNames = packmaster_packs.stream().map(packID -> {
+                AbstractCardPack pack = SpireAnniversary5Mod.packsByID.getOrDefault(packID, null);
+                return pack != null ? pack.name : packID;
+            }).collect(Collectors.toList());
+            String packsText = String.join(", ", packNames);
+
+            ReflectionHacks.RMethod renderSubHeadingWithMessageMethod = ReflectionHacks.privateMethod(RunHistoryScreen.class, "renderSubHeadingWithMessage", SpriteBatch.class, String.class, String.class, float.class, float.class);
+            renderSubHeadingWithMessageMethod.invoke(__instance, sb, headerText, packsText, header2x, yOffset[0]);
+
+            ReflectionHacks.RMethod screenPosY = ReflectionHacks.privateMethod(RunHistoryScreen.class, "screenPosY", float.class);
+            yOffset[0] = yOffset[0] - (float)screenPosY.invoke(__instance, 40.0F);
+        }
+
+        public static class Locator extends SpireInsertLocator {
+            public int[] Locate(CtBehavior ctMethodToPatch) throws CannotCompileException, PatchingException {
+                Matcher matcher = new Matcher.MethodCallMatcher(RunHistoryScreen.class, "renderRelics");
+                return LineFinder.findInOrder(ctMethodToPatch, matcher);
+            }
+        }
+    }
+}

--- a/src/main/java/thePackmaster/powers/replicatorspack/EnergyDrinkPower.java
+++ b/src/main/java/thePackmaster/powers/replicatorspack/EnergyDrinkPower.java
@@ -17,7 +17,7 @@ public class EnergyDrinkPower extends AbstractPackmasterPower implements Cloneab
 
 
     public EnergyDrinkPower(AbstractCreature owner, int amount) {
-        super(POWER_ID,NAME, AbstractPower.PowerType.BUFF,true,owner,amount);
+        super(POWER_ID,NAME, AbstractPower.PowerType.BUFF,false,owner,amount);
 
     }
 

--- a/src/main/java/thePackmaster/relics/BagOfHolding.java
+++ b/src/main/java/thePackmaster/relics/BagOfHolding.java
@@ -1,10 +1,20 @@
 package thePackmaster.relics;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import thePackmaster.SpireAnniversary5Mod;
+
+import java.text.DecimalFormat;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
@@ -27,6 +37,7 @@ public class BagOfHolding extends AbstractPackmasterRelic {
             addToTop(new RelicAboveCreatureAction(AbstractDungeon.player, this));
             addToTop(new GainEnergyAction(1));
             this.counter--;
+            this.incrementEnergyStat();
 
             if (this.counter <= 0) {
                 this.counter = -1;
@@ -60,8 +71,6 @@ public class BagOfHolding extends AbstractPackmasterRelic {
         return AbstractDungeon.player.hasRelic(HandyHaversack.ID);
     }
 
-
-
     @Override
     public String getUpdatedDescription() {
         // Colorize the starter relic's name. Thanks Bard!!! Thanks Nelly!!!!! HAPPY BIRTHDAY, STS MODDING!!!
@@ -81,5 +90,49 @@ public class BagOfHolding extends AbstractPackmasterRelic {
         return DESCRIPTIONS[0] + sb + DESCRIPTIONS[1];
     }
 
+    private static final Map<String, Integer> stats = new HashMap<>();
+    public static String ENERGY_STAT = "energy";
+
+    public String getStatsDescription() {
+        if (stats.get(ENERGY_STAT) == null) {
+            return "";
+        }
+        return DESCRIPTIONS[2].replace("{0}", stats.get(ENERGY_STAT) + "");
+    }
+
+    public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
+        if (stats.get(ENERGY_STAT) == null) {
+            return "";
+        }
+        DecimalFormat format = new DecimalFormat("#.###");
+        float block = stats.get(ENERGY_STAT);
+        String energyPerTurn = format.format(block / Math.max(totalTurns, 1));
+        String energyPerCombat = format.format(block / Math.max(totalCombats, 1));
+        return getStatsDescription() + DESCRIPTIONS[3].replace("{0}", energyPerTurn).replace("{1}", energyPerCombat);
+    }
+
+    public void resetStats() {
+        stats.put(ENERGY_STAT, 0);
+    }
+
+    public JsonElement onSaveStats() {
+        Gson gson = new Gson();
+        List<Integer> statsToSave = new ArrayList<>();
+        statsToSave.add(stats.get(ENERGY_STAT));
+        return gson.toJsonTree(statsToSave);
+    }
+
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            stats.put(ENERGY_STAT, jsonArray.get(0).getAsInt());
+        } else {
+            resetStats();
+        }
+    }
+
+    public static void incrementEnergyStat() {
+        stats.put(ENERGY_STAT, stats.getOrDefault(ENERGY_STAT, 0) + 1);
+    }
 }
 

--- a/src/main/java/thePackmaster/relics/BanishingDecree.java
+++ b/src/main/java/thePackmaster/relics/BanishingDecree.java
@@ -1,8 +1,10 @@
 package thePackmaster.relics;
 
-import basemod.BaseMod;
 import basemod.abstracts.CustomSavable;
 import com.evacipated.cardcrawl.mod.stslib.cards.interfaces.SpawnModificationCard;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -12,23 +14,20 @@ import com.megacrit.cardcrawl.helpers.PowerTip;
 import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.rewards.RewardItem;
-import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.rooms.ShopRoom;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.packs.AbstractCardPack;
 import thePackmaster.util.Wiz;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static thePackmaster.SpireAnniversary5Mod.*;
 
 public class BanishingDecree extends AbstractPackmasterRelic implements CustomSavable<ArrayList<String>> {
     public static final String ID = makeID("BanishingDecree");
-    public String bannedPack = null;
-    public String newPack = null;
+    public String bannedPackID = null;
+    public String newPackID = null;
     private boolean cardSelected = true;
     private boolean cardSelected2 = true;
 
@@ -36,19 +35,29 @@ public class BanishingDecree extends AbstractPackmasterRelic implements CustomSa
         super(ID, RelicTier.SHOP, LandingSound.FLAT);
     }
 
+    // We should really only save and load the IDs, but this was originally written to save and load the names, and
+    // we've kept that around to avoid potential backwards compatibility issues (e.g. breaking runs that people were in
+    // the middle of when they get a code update)
     @Override
     public ArrayList<String> onSave() {
         ArrayList<String> saves = new ArrayList<>();
-        saves.add(bannedPack);
-        saves.add(newPack);
+        AbstractCardPack bannedPack = packsByID.getOrDefault(bannedPackID, null);
+        AbstractCardPack newPack = packsByID.getOrDefault(newPackID, null);
+        saves.add(bannedPack != null ? bannedPack.name : null);
+        saves.add(newPack != null ? newPack.name : null);
+        saves.add(bannedPackID);
+        saves.add(newPackID);
         return saves;
     }
 
     @Override
-    public void onLoad(ArrayList<String> bannedPackID) {
-        bannedPack = bannedPackID.get(0);
-        newPack = bannedPackID.get(1);
-        if (bannedPack != null) setDescriptionAfterLoading();
+    public void onLoad(ArrayList<String> packNamesAndIDs) {
+        bannedPackID = packNamesAndIDs.get(2);
+        newPackID = packNamesAndIDs.get(3);
+        if (packsByID.containsKey(bannedPackID) && packsByID.containsKey(newPackID)) {
+            setDescriptionAfterLoading();
+            recordStats(bannedPackID, newPackID);
+        }
     }
 
     @Override
@@ -77,8 +86,8 @@ public class BanishingDecree extends AbstractPackmasterRelic implements CustomSa
                 cardSelected = true;
                 AbstractCard card = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
                 AbstractCardPack cp = Wiz.getPackByCard(card);
-                bannedPack = cp.name;
-                SpireAnniversary5Mod.logger.info("Banned Pack" + bannedPack);
+                bannedPackID = cp.packID;
+                SpireAnniversary5Mod.logger.info("Banned Pack" + bannedPackID);
                 SpireAnniversary5Mod.currentPoolPacks.remove(cp);
                 AbstractDungeon.gridSelectScreen.selectedCards.clear();
 
@@ -97,8 +106,8 @@ public class BanishingDecree extends AbstractPackmasterRelic implements CustomSa
                 cardSelected2 = true;
                 AbstractCard card = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
                 AbstractCardPack cp = Wiz.getPackByCard(card);
-                newPack = cp.name;
-                SpireAnniversary5Mod.logger.info("New Pack" + newPack);
+                newPackID = cp.packID;
+                SpireAnniversary5Mod.logger.info("New Pack" + newPackID);
                 SpireAnniversary5Mod.currentPoolPacks.add(cp);
                 CardCrawlGame.dungeon.initializeCardPools();
 
@@ -128,16 +137,18 @@ public class BanishingDecree extends AbstractPackmasterRelic implements CustomSa
                 AbstractDungeon.combatRewardScreen.open(this.DESCRIPTIONS[6]);
                 skipDefaultCardRewards = false;
                 AbstractDungeon.getCurrRoom().rewardPopOutTimer = 0.0F;
-
+                recordStats(bannedPackID, newPackID);
             }
         }
     }
 
     private void setDescriptionAfterLoading() {
-        SpireAnniversary5Mod.logger.info("Banned Pack" + bannedPack);
-        SpireAnniversary5Mod.logger.info("New Pack" + newPack);
-        this.description = this.DESCRIPTIONS[2] + bannedPack + this.DESCRIPTIONS[3];
-        this.description = this.description + " NL " + this.DESCRIPTIONS[2] + newPack + this.DESCRIPTIONS[4];
+        SpireAnniversary5Mod.logger.info("Banned Pack" + bannedPackID);
+        SpireAnniversary5Mod.logger.info("New Pack" + newPackID);
+        String bannedPackName = packsByID.get(bannedPackID).name;
+        String newPackName = packsByID.get(newPackID).name;
+        this.description = this.DESCRIPTIONS[2] + bannedPackName + this.DESCRIPTIONS[3];
+        this.description = this.description + " NL " + this.DESCRIPTIONS[2] + newPackName + this.DESCRIPTIONS[4];
         tips.clear();
         tips.add(new PowerTip(name, description));
         initializeTips();
@@ -145,5 +156,49 @@ public class BanishingDecree extends AbstractPackmasterRelic implements CustomSa
 
     public String getUpdatedDescription() {
         return DESCRIPTIONS[0];
+    }
+
+    private static final Map<String, String> stats = new HashMap<>();
+    private static final String BANNED_STAT = "banned";
+    private static final String NEW_STAT = "new";
+
+    public String getStatsDescription() {
+        AbstractCardPack bannedPack = SpireAnniversary5Mod.packsByID.getOrDefault(stats.get(BANNED_STAT), null);
+        AbstractCardPack newPack = SpireAnniversary5Mod.packsByID.getOrDefault(stats.get(NEW_STAT), null);
+        return bannedPack != null && newPack != null ? DESCRIPTIONS[10].replace("{0}", bannedPack.name).replace("{1}", newPack.name) : "";
+    }
+
+    public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
+        return getStatsDescription();
+    }
+
+    public void resetStats() {
+        stats.put(BANNED_STAT, null);
+        stats.put(NEW_STAT, null);
+    }
+
+    public JsonElement onSaveStats() {
+        Gson gson = new Gson();
+        List<String> statsToSave = new ArrayList<>();
+        statsToSave.add(stats.get(BANNED_STAT));
+        statsToSave.add(stats.get(NEW_STAT));
+        return gson.toJsonTree(statsToSave);
+    }
+
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            JsonElement bannedPackID = jsonArray.get(0);
+            JsonElement newPackID = jsonArray.get(1);
+            stats.put(BANNED_STAT, !bannedPackID.isJsonNull() ? bannedPackID.getAsString() : null);
+            stats.put(NEW_STAT, !newPackID.isJsonNull() ? newPackID.getAsString() : null);
+        } else {
+            resetStats();
+        }
+    }
+
+    public static void recordStats(String bannedPackID, String newPackID) {
+        stats.put(BANNED_STAT, bannedPackID);
+        stats.put(NEW_STAT, newPackID);
     }
 }

--- a/src/main/java/thePackmaster/relics/CollectorBadge.java
+++ b/src/main/java/thePackmaster/relics/CollectorBadge.java
@@ -1,5 +1,8 @@
 package thePackmaster.relics;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
 import com.megacrit.cardcrawl.actions.utility.UseCardAction;
@@ -8,7 +11,11 @@ import com.megacrit.cardcrawl.helpers.PowerTip;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.util.Wiz;
 
+import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
@@ -57,6 +64,7 @@ public class CollectorBadge extends AbstractPackmasterRelic {
                     flash();
                     Wiz.atb(new RelicAboveCreatureAction(Wiz.p(), this));
                     addToBot(new GainEnergyAction(1));
+                    incrementEnergyStat();
                 }
                 setDescriptionAfterLoading();
             }
@@ -86,4 +94,48 @@ public class CollectorBadge extends AbstractPackmasterRelic {
         initializeTips();
     }
 
+    private static final Map<String, Integer> stats = new HashMap<>();
+    public static String ENERGY_STAT = "energy";
+
+    public String getStatsDescription() {
+        if (stats.get(ENERGY_STAT) == null) {
+            return "";
+        }
+        return DESCRIPTIONS[3].replace("{0}", stats.get(ENERGY_STAT) + "");
+    }
+
+    public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
+        if (stats.get(ENERGY_STAT) == null) {
+            return "";
+        }
+        DecimalFormat format = new DecimalFormat("#.###");
+        float block = stats.get(ENERGY_STAT);
+        String energyPerTurn = format.format(block / Math.max(totalTurns, 1));
+        String energyPerCombat = format.format(block / Math.max(totalCombats, 1));
+        return getStatsDescription() + DESCRIPTIONS[4].replace("{0}", energyPerTurn).replace("{1}", energyPerCombat);
+    }
+
+    public void resetStats() {
+        stats.put(ENERGY_STAT, 0);
+    }
+
+    public JsonElement onSaveStats() {
+        Gson gson = new Gson();
+        List<Integer> statsToSave = new ArrayList<>();
+        statsToSave.add(stats.get(ENERGY_STAT));
+        return gson.toJsonTree(statsToSave);
+    }
+
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            stats.put(ENERGY_STAT, jsonArray.get(0).getAsInt());
+        } else {
+            resetStats();
+        }
+    }
+
+    public static void incrementEnergyStat() {
+        stats.put(ENERGY_STAT, stats.getOrDefault(ENERGY_STAT, 0) + 1);
+    }
 }

--- a/src/main/java/thePackmaster/relics/GemOfUnity.java
+++ b/src/main/java/thePackmaster/relics/GemOfUnity.java
@@ -1,5 +1,8 @@
 package thePackmaster.relics;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.actions.common.GainBlockAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -11,7 +14,11 @@ import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.packs.AbstractCardPack;
 import thePackmaster.util.Wiz;
 
+import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
@@ -58,6 +65,7 @@ public class GemOfUnity extends AbstractPackmasterRelic {
                 Wiz.applyToSelf(new StrengthPower(Wiz.p(), 1));
                 Wiz.applyToSelf(new DexterityPower(Wiz.p(), 1));
                 grayscale = true;
+                incrementTimesStat();
             }
         }
         this.description = getUpdatedDescription();
@@ -80,5 +88,49 @@ public class GemOfUnity extends AbstractPackmasterRelic {
             }
         }
         return desc.toString();
+    }
+
+    private static final Map<String, Integer> stats = new HashMap<>();
+    public static String TIMES_STAT = "times";
+
+    public String getStatsDescription() {
+        if (stats.get(TIMES_STAT) == null) {
+            return "";
+        }
+        return DESCRIPTIONS[2].replace("{0}", stats.get(TIMES_STAT) + "");
+    }
+
+    public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
+        if (stats.get(TIMES_STAT) == null) {
+            return "";
+        }
+        DecimalFormat format = new DecimalFormat("#.###");
+        float block = stats.get(TIMES_STAT);
+        String timesPerCombat = format.format(block / Math.max(totalCombats, 1));
+        return getStatsDescription() + DESCRIPTIONS[3].replace("{0}", timesPerCombat);
+    }
+
+    public void resetStats() {
+        stats.put(TIMES_STAT, 0);
+    }
+
+    public JsonElement onSaveStats() {
+        Gson gson = new Gson();
+        List<Integer> statsToSave = new ArrayList<>();
+        statsToSave.add(stats.get(TIMES_STAT));
+        return gson.toJsonTree(statsToSave);
+    }
+
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            stats.put(TIMES_STAT, jsonArray.get(0).getAsInt());
+        } else {
+            resetStats();
+        }
+    }
+
+    public static void incrementTimesStat() {
+        stats.put(TIMES_STAT, stats.getOrDefault(TIMES_STAT, 0) + 1);
     }
 }

--- a/src/main/java/thePackmaster/relics/PMBoosterBox.java
+++ b/src/main/java/thePackmaster/relics/PMBoosterBox.java
@@ -2,6 +2,9 @@ package thePackmaster.relics;
 
 import basemod.abstracts.CustomSavable;
 import com.evacipated.cardcrawl.mod.stslib.patches.CenterGridCardSelectScreen;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -12,8 +15,7 @@ import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.packs.AbstractCardPack;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.*;
 
 import static thePackmaster.SpireAnniversary5Mod.*;
 
@@ -122,6 +124,7 @@ public class PMBoosterBox extends AbstractPackmasterRelic implements CustomSavab
 
             if (numPicked == 3) {
                 AbstractDungeon.getCurrRoom().phase = AbstractRoom.RoomPhase.COMPLETE;
+                recordStats(myPackOne, myPackTwo, myPackThree, 0);
                 setDescriptionAfterLoading();
                 makeIDArray();
             } else {
@@ -155,5 +158,67 @@ public class PMBoosterBox extends AbstractPackmasterRelic implements CustomSavab
     @Override
     public boolean canSpawn() {
         return Settings.isEndless || AbstractDungeon.floorNum <= 48;
+    }
+
+    private static final Map<String, Object> stats = new HashMap<>();
+    private static final String PACK1_STAT = "pack1";
+    private static final String PACK2_STAT = "pack2";
+    private static final String PACK3_STAT = "pack3";
+    private static final String REWARDS_STAT = "rewards";
+
+    public String getStatsDescription() {
+        AbstractCardPack pack1 = SpireAnniversary5Mod.packsByID.getOrDefault((String)stats.get(PACK1_STAT), null);
+        AbstractCardPack pack2 = SpireAnniversary5Mod.packsByID.getOrDefault((String)stats.get(PACK2_STAT), null);
+        AbstractCardPack pack3 = SpireAnniversary5Mod.packsByID.getOrDefault((String)stats.get(PACK3_STAT), null);
+        String rewards = stats.get(REWARDS_STAT) + "";
+        return pack1 != null && pack2 != null && pack3 != null ? DESCRIPTIONS[3].replace("{0}", pack1.name).replace("{1}", pack2.name).replace("{2}", pack3.name).replace("{3}", rewards) : "";
+    }
+
+    public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
+        return getStatsDescription();
+    }
+
+    public void resetStats() {
+        stats.put(PACK1_STAT, null);
+        stats.put(PACK2_STAT, null);
+        stats.put(PACK3_STAT, null);
+        stats.put(REWARDS_STAT, 0);
+    }
+
+    public JsonElement onSaveStats() {
+        Gson gson = new Gson();
+        List<Object> statsToSave = new ArrayList<>();
+        statsToSave.add(stats.get(PACK1_STAT));
+        statsToSave.add(stats.get(PACK2_STAT));
+        statsToSave.add(stats.get(PACK3_STAT));
+        statsToSave.add(stats.get(REWARDS_STAT));
+        return gson.toJsonTree(statsToSave);
+    }
+
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            JsonElement pack1 = jsonArray.get(0);
+            JsonElement pack2 = jsonArray.get(1);
+            JsonElement pack3 = jsonArray.get(2);
+            JsonElement rewards = jsonArray.get(3);
+            stats.put(PACK1_STAT, !pack1.isJsonNull() ? pack1.getAsString() : null);
+            stats.put(PACK2_STAT, !pack2.isJsonNull() ? pack2.getAsString() : null);
+            stats.put(PACK3_STAT, !pack2.isJsonNull() ? pack3.getAsString() : null);
+            stats.put(REWARDS_STAT, !rewards.isJsonNull() ? rewards.getAsInt() : null);
+        } else {
+            resetStats();
+        }
+    }
+
+    public static void recordStats(String pack1, String pack2, String pack3, int rewards) {
+        stats.put(PACK1_STAT, pack1);
+        stats.put(PACK2_STAT, pack2);
+        stats.put(PACK3_STAT, pack3);
+        stats.put(REWARDS_STAT, rewards);
+    }
+
+    public static void incrementRewards() {
+        stats.put(REWARDS_STAT, (Integer)stats.getOrDefault(REWARDS_STAT, 0) + 1);
     }
 }

--- a/src/main/java/thePackmaster/relics/PMBoosterPack.java
+++ b/src/main/java/thePackmaster/relics/PMBoosterPack.java
@@ -1,6 +1,9 @@
 package thePackmaster.relics;
 
 import com.evacipated.cardcrawl.mod.stslib.patches.CenterGridCardSelectScreen;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.core.Settings;
@@ -10,8 +13,12 @@ import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
 import thePackmaster.SpireAnniversary5Mod;
+import thePackmaster.packs.AbstractCardPack;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
@@ -41,7 +48,8 @@ public class PMBoosterPack extends AbstractPackmasterRelic {
         AbstractDungeon.getCurrRoom().phase = AbstractRoom.RoomPhase.INCOMPLETE;
         CenterGridCardSelectScreen.centerGridSelect = true;
         CardGroup group = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
-        ArrayList<String> cards = SpireAnniversary5Mod.getRandomPackFromAll(new Random(Settings.seed + 41)).getCards();
+        AbstractCardPack pack = SpireAnniversary5Mod.getRandomPackFromAll(new Random(Settings.seed + 41));
+        ArrayList<String> cards = pack.getCards();
         for (String s : cards) {
            if (CardLibrary.getCard(s).rarity == AbstractCard.CardRarity.COMMON ||
                    CardLibrary.getCard(s).rarity == AbstractCard.CardRarity.UNCOMMON ||
@@ -50,6 +58,7 @@ public class PMBoosterPack extends AbstractPackmasterRelic {
         }
         group.sortByRarity(false);
 
+        recordStats(pack.packID);
         AbstractDungeon.gridSelectScreen.open(group, 1, DESCRIPTIONS[1], false, false, false, false);
     }
 
@@ -66,5 +75,42 @@ public class PMBoosterPack extends AbstractPackmasterRelic {
             AbstractDungeon.getCurrRoom().phase = lastPhase;
 
         }
+    }
+
+    private static final Map<String, String> stats = new HashMap<>();
+    private static final String PACK_STAT = "pack";
+
+    public String getStatsDescription() {
+        AbstractCardPack pack = SpireAnniversary5Mod.packsByID.getOrDefault(stats.get(PACK_STAT), null);
+        return pack != null ? DESCRIPTIONS[2].replace("{0}", pack.name) : "";
+    }
+
+    public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
+        return getStatsDescription();
+    }
+
+    public void resetStats() {
+        stats.put(PACK_STAT, null);
+    }
+
+    public JsonElement onSaveStats() {
+        Gson gson = new Gson();
+        List<String> statsToSave = new ArrayList<>();
+        statsToSave.add(stats.get(PACK_STAT));
+        return gson.toJsonTree(statsToSave);
+    }
+
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            JsonElement pack = jsonArray.get(0);
+            stats.put(PACK_STAT, !pack.isJsonNull() ? pack.getAsString() : null);
+        } else {
+            resetStats();
+        }
+    }
+
+    public static void recordStats(String pack) {
+        stats.put(PACK_STAT, pack);
     }
 }

--- a/src/main/java/thePackmaster/relics/PMCollection.java
+++ b/src/main/java/thePackmaster/relics/PMCollection.java
@@ -1,15 +1,23 @@
 package thePackmaster.relics;
 
 import com.evacipated.cardcrawl.mod.stslib.StSLib;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.rewards.RewardItem;
+import thePackmaster.SpireAnniversary5Mod;
+import thePackmaster.packs.AbstractCardPack;
 import thePackmaster.util.Wiz;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static thePackmaster.SpireAnniversary5Mod.*;
 
@@ -24,8 +32,8 @@ public class PMCollection extends AbstractPackmasterRelic {
     public void onEquip() {
         AbstractDungeon.getCurrRoom().rewards.clear();
 
-        for (String s :
-                getRandomPackFromAll(new Random(Settings.seed + 37)).getCards()) {
+        AbstractCardPack pack = getRandomPackFromAll(new Random(Settings.seed + 37));
+        for (String s : pack.getCards()) {
             if (CardLibrary.getCard(s).rarity == AbstractCard.CardRarity.COMMON ||
                     CardLibrary.getCard(s).rarity == AbstractCard.CardRarity.UNCOMMON ||
                     CardLibrary.getCard(s).rarity == AbstractCard.CardRarity.RARE) {
@@ -36,13 +44,49 @@ public class PMCollection extends AbstractPackmasterRelic {
                 r.cards.forEach(c -> Wiz.p().relics.forEach(rel -> rel.onPreviewObtainCard(c)));
                 AbstractDungeon.getCurrRoom().addCardReward(r);
             }
-
-
         }
 
+        recordStats(pack.packID);
         skipDefaultCardRewards = true;
         AbstractDungeon.combatRewardScreen.open(this.DESCRIPTIONS[1]);
         skipDefaultCardRewards = false;
         AbstractDungeon.getCurrRoom().rewardPopOutTimer = 0.0F;
+    }
+
+    private static final Map<String, String> stats = new HashMap<>();
+    private static final String PACK_STAT = "pack";
+
+    public String getStatsDescription() {
+        AbstractCardPack pack = SpireAnniversary5Mod.packsByID.getOrDefault(stats.get(PACK_STAT), null);
+        return pack != null ? DESCRIPTIONS[2].replace("{0}", pack.name) : "";
+    }
+
+    public String getExtendedStatsDescription(int totalCombats, int totalTurns) {
+        return getStatsDescription();
+    }
+
+    public void resetStats() {
+        stats.put(PACK_STAT, null);
+    }
+
+    public JsonElement onSaveStats() {
+        Gson gson = new Gson();
+        List<String> statsToSave = new ArrayList<>();
+        statsToSave.add(stats.get(PACK_STAT));
+        return gson.toJsonTree(statsToSave);
+    }
+
+    public void onLoadStats(JsonElement jsonElement) {
+        if (jsonElement != null) {
+            JsonArray jsonArray = jsonElement.getAsJsonArray();
+            JsonElement pack = jsonArray.get(0);
+            stats.put(PACK_STAT, !pack.isJsonNull() ? pack.getAsString() : null);
+        } else {
+            resetStats();
+        }
+    }
+
+    public static void recordStats(String pack) {
+        stats.put(PACK_STAT, pack);
     }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/Eventstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Eventstrings.json
@@ -31,7 +31,7 @@
       "[Locked] No Cards to remove.",
       "[Learn Dark Arts] #rBecome #rCursed #r- #rBell. #gObtain #gConjure #gPack.",
       "[Take Sample] #gObtain #gPack #gRip #gPotion.",
-      "[Cleansing Ritual] Remove a card from your Deck.",
+      "[Cleansing Ritual] #gRemove #ga #gcard #gfrom #gyour #gDeck.",
       "[Locked] No cards to remove.",
       "[Buy Collection] #rLose #r",
       " #rGold. #gObtain #gPM #gCollection.",

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -60,7 +60,8 @@
     "DESCRIPTIONS": [
       "Upon pickup, choose #b1 of #b3 Packmaster Boosters, three times. Earn an additional card from these boosters at the end of each combat.",
       " NL Chosen Boosters: ",
-      "Choose a Booster Pack."
+      "Choose a Booster Pack.",
+      "Packs: {0}, {1}, {2} NL Extra card rewards: {3}"
     ]
   },
   "${ModID}:PMBoosterPack": {
@@ -68,7 +69,8 @@
     "FLAVOR": "A package of cards in a foil wrapper. How did it end up in the Spire?",
     "DESCRIPTIONS": [
       "Upon pickup, add any one card from a random Packmaster Booster to your deck.",
-      "Choose a card to add to your deck."
+      "Choose a card to add to your deck.",
+      "Pack: {0}"
     ]
   },
   "${ModID}:PMCollection": {
@@ -76,7 +78,8 @@
     "FLAVOR": "Said to have been assembled by a consortium of wizards.",
     "DESCRIPTIONS": [
       "Upon pickup, you may add each card from a random Packmaster Booster to your deck.",
-      "You may add this to your deck."
+      "You may add this to your deck.",
+      "Pack: {0}"
     ]
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Relicstrings.json
@@ -4,7 +4,9 @@
     "FLAVOR": "\"Incredible! It appears that this bag connects to an extradimensional space. What if I jump inside?\" - Ranwid",
     "DESCRIPTIONS": [
       "Replaces ",
-      ".[] NL Gain [E] at the start of each turn, lasting one turn for every #b5 cards in your deck."
+      ".[] NL Gain [E] at the start of each turn, lasting one turn for every #b5 cards in your deck.",
+      "Energy gained: {0}",
+      " NL Per turn: {0} NL Per combat: {1}"
     ]
   },
   "${ModID}:BanishingDecree": {
@@ -20,7 +22,8 @@
       "Power!",
       ".",
       ".",
-      "Translator note: The 2 dots up here follows the structure 'Choose a Pack to banish with '+'Banishing Decree'+'.' and 'Choose a Pack to gain with '+'Banishing Decree'+'.' respectively. "
+      "Translator note: The 2 dots up here follows the structure 'Choose a Pack to banish with '+'Banishing Decree'+'.' and 'Choose a Pack to gain with '+'Banishing Decree'+'.' respectively. ",
+      "Banished pack: {0} NL Added pack: {1}"
     ]
   },
   "${ModID}:CollectorBadge": {
@@ -29,7 +32,9 @@
     "DESCRIPTIONS": [
       "Each turn, after you play a card from #b4 different Packs, gain [E] [REMOVE_SPACE].",
       " NL NL Packs used this turn: ",
-      " NL NL This has triggered this turn. "
+      " NL NL This has triggered this turn. ",
+      "Energy gained: {0}",
+      " NL Per turn: {0} NL Per combat: {1}"
     ]
   },
   "${ModID}:GemOfUnity": {
@@ -37,7 +42,9 @@
     "FLAVOR": "In union there is strength.",
     "DESCRIPTIONS": [
       "Once per combat, after you have played a card from each different Pack available this run, gain #b20 Block, #b1 Strength, #b1 Dexterity, and heal #b5 HP.",
-      "Packs played this combat: "
+      "Packs played this combat: ",
+      "Times triggered: {0}",
+      " NL Per combat: {0}"
     ]
   },
   "${ModID}:HandyHaversack": {

--- a/src/main/resources/anniv5Resources/localization/eng/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/UIstrings.json
@@ -120,6 +120,11 @@
       "By Packs"
     ]
   },
+  "${ModID}:RunHistory": {
+    "TEXT": [
+      "Packs:"
+    ]
+  },
   "${ModID}:CardTypeStrings": {
     "TEXT": [
       "Chance"


### PR DESCRIPTION
This PR has a few different changes. I started doing one thing (relic stats), then wanted to play a few runs to test it since the code to get this working is sometimes a bit quirky, then kept finding new QOL stuff to add. There were a variety of things (mostly in run history) that I realized wanted to add for the Packmaster.

Here's what you can include in the changelog for this:
* Add relic stats for Bag of Holding, Banishing Decree, Collector Badge, and Gem of Unity, PM Booster Box, PM Booster Pack, and PM Collection
* Show the list of packs in run history for Packmaster runs
* Replicators pack: fix Energy Drink being marked as a turn-based buff
* Character event: add text coloring for remove card option
* Character event: show event name in run history
* Character event: show event choices in run history
* Character event: fix the relic options not costing gold

It shouldn't be too hard to tell which code changes are associated with each changelog entry. The files involved are different for each one and the code is mostly straightforward, which is why I didn't think it was worth the time to split this into multiple different PRs.