### PR TITLE
Core Set Updates

### DIFF
--- a/src/main/java/thePackmaster/cards/AbstractPackmasterCard.java
+++ b/src/main/java/thePackmaster/cards/AbstractPackmasterCard.java
@@ -24,9 +24,12 @@ import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.ThePackmaster;
 import thePackmaster.packs.AbstractCardPack;
+import thePackmaster.packs.CoreSetPack;
 import thePackmaster.patches.rippack.AllCardsRippablePatches;
 import thePackmaster.util.CardArtRoller;
 import thePackmaster.util.Wiz;
+
+import java.util.Objects;
 
 import static thePackmaster.SpireAnniversary5Mod.makeImagePath;
 import static thePackmaster.SpireAnniversary5Mod.modID;
@@ -386,5 +389,22 @@ public abstract class AbstractPackmasterCard extends CustomCard {
         if (!(SingleCardViewPopup.isViewingUpgrade && this.isSeen && !this.isLocked)) {
             renderBorderText(sb);
         }
+    }
+
+
+    public int otherPacksInHandCheck() {
+        long otherPacksInHand = AbstractDungeon.player.hand.group.stream()
+                .map(c -> SpireAnniversary5Mod.cardParentMap.getOrDefault(c.cardID, null))
+                .filter(Objects::nonNull)
+                .distinct()
+                .count();
+        return ((int) otherPacksInHand);
+    }
+
+    public boolean hasSynergy() {
+        return otherPacksInHandCheck() >= 3;
+    }
+    public boolean hasSynergyWhenPlayed() {
+        return otherPacksInHandCheck() >= 2;
     }
 }

--- a/src/main/java/thePackmaster/cards/AbstractPackmasterCard.java
+++ b/src/main/java/thePackmaster/cards/AbstractPackmasterCard.java
@@ -395,16 +395,13 @@ public abstract class AbstractPackmasterCard extends CustomCard {
     public int otherPacksInHandCheck() {
         long otherPacksInHand = AbstractDungeon.player.hand.group.stream()
                 .map(c -> SpireAnniversary5Mod.cardParentMap.getOrDefault(c.cardID, null))
-                .filter(Objects::nonNull)
+                .filter(s -> s != null && !s.equals(SpireAnniversary5Mod.cardParentMap.get(this.cardID)))
                 .distinct()
                 .count();
         return ((int) otherPacksInHand);
     }
 
     public boolean hasSynergy() {
-        return otherPacksInHandCheck() >= 3;
-    }
-    public boolean hasSynergyWhenPlayed() {
         return otherPacksInHandCheck() >= 2;
     }
 }

--- a/src/main/java/thePackmaster/cards/coresetpack/BackpackSmack.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/BackpackSmack.java
@@ -3,36 +3,63 @@ package thePackmaster.cards.coresetpack;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DrawCardAction;
 import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
+import com.megacrit.cardcrawl.actions.common.MakeTempCardInDrawPileAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.StrengthPower;
+import thePackmaster.actions.EasyXCostAction;
 import thePackmaster.cards.AbstractPackmasterCard;
+import thePackmaster.cards.highenergypack.Food;
+import thePackmaster.util.Wiz;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
+import static thePackmaster.util.Wiz.atb;
+import static thePackmaster.util.Wiz.att;
 
 public class BackpackSmack extends AbstractPackmasterCard {
     public final static String ID = makeID("BackpackSmack");
-    // intellij stuff attack, enemy, basic, 6, 3,  , , ,
+
+    private boolean synergyOn;
 
     public BackpackSmack() {
-        super(ID, 1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
-        baseDamage = 7;
+        super(ID, -1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
+        baseDamage = 6;
         magicNumber = baseMagicNumber = 2;
 
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
-        dmg(m, AbstractGameAction.AttackEffect.BLUNT_HEAVY);
-        if (p.drawPile.size() >= 10) {
-            AbstractDungeon.actionManager.addToBottom(new DrawCardAction(p, this.magicNumber));
-        }
-        else {
-            AbstractDungeon.actionManager.addToBottom(new GainEnergyAction(1));
+        synergyOn = (hasSynergy());
+
+        atb(new EasyXCostAction(this, (effect, params) -> {
+            for (int i = 0; i < effect; i++) {
+                dmgTop(m, AbstractGameAction.AttackEffect.BLUNT_HEAVY);
+            }
+            return true;
+        }));
+
+        addToBot(new AbstractGameAction() {
+            @Override
+            public void update() {
+                isDone = true;
+                if (synergyOn) {
+                    Wiz.atb(new GainEnergyAction(1));
+                }
+            }
+        });
+
+    }
+    @Override
+    public void triggerOnGlowCheck() {
+        this.glowColor = AbstractCard.BLUE_BORDER_GLOW_COLOR.cpy();
+        if (hasSynergy()) {
+            this.glowColor = AbstractCard.GOLD_BORDER_GLOW_COLOR.cpy();
         }
     }
 
     public void upp() {
-        upgradeDamage(2);
-        upgradeMagicNumber(1);
+        upgradeDamage(3);
     }
 }

--- a/src/main/java/thePackmaster/cards/coresetpack/RippedPecs.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/RippedPecs.java
@@ -1,12 +1,14 @@
 package thePackmaster.cards.coresetpack;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.UpgradeRandomCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.DexterityPower;
 import com.megacrit.cardcrawl.powers.StrengthPower;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.cards.AbstractPackmasterCard;
@@ -18,46 +20,37 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public class RippedPecs extends AbstractPackmasterCard {
     public final static String ID = makeID("RippedPecs");
-    private static final CardStrings cardStrings = CardCrawlGame.languagePack.getCardStrings(ID);
 
+    private boolean synergyOn;
     public RippedPecs() {
         super(ID, 1, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
-        this.exhaust = true;
+        baseMagicNumber = magicNumber = 2;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
-        this.addToBot(new AbstractGameAction() {
+        synergyOn = (hasSynergy());
+
+        Wiz.applyToSelfTop(new StrengthPower(p, 1));
+        addToBot(new AbstractGameAction() {
             @Override
             public void update() {
-                int strength = getPacksPlayedThisCombat(false);
-                if (strength > 0)
-                    Wiz.applyToSelfTop(new StrengthPower(p, strength));
-                this.isDone = true;
+                isDone = true;
+                if (synergyOn) {
+                    Wiz.applyToSelfTop(new StrengthPower(p, magicNumber));
+                }
             }
         });
     }
 
     public void upp() {
-        this.exhaust = false;
+        upgradeMagicNumber(1);
     }
 
     @Override
-    public void applyPowers() {
-        this.rawDescription = (this.upgraded ? cardStrings.UPGRADE_DESCRIPTION : cardStrings.DESCRIPTION) + cardStrings.EXTENDED_DESCRIPTION[0].replace("{0}", this.getPacksPlayedThisCombat(true) + "");
-        this.initializeDescription();
-    }
-
-    private int getPacksPlayedThisCombat(boolean forApplyPowers) {
-        int n = forApplyPowers ? 1 : 2;
-        HashSet<String> packs = new HashSet<>();
-        if (AbstractDungeon.actionManager.cardsPlayedThisCombat.size() >= n) {
-            for (AbstractCard c : AbstractDungeon.actionManager.cardsPlayedThisCombat.subList(0, AbstractDungeon.actionManager.cardsPlayedThisCombat.size() - n + 1)) {
-                String parentID = SpireAnniversary5Mod.cardParentMap.get(c.cardID);
-                if (parentID != null) {
-                    packs.add(parentID);
-                }
-            }
+    public void triggerOnGlowCheck() {
+        this.glowColor = AbstractCard.BLUE_BORDER_GLOW_COLOR.cpy();
+        if (hasSynergy()) {
+            this.glowColor = AbstractCard.GOLD_BORDER_GLOW_COLOR.cpy();
         }
-        return packs.size();
     }
 }

--- a/src/main/java/thePackmaster/cards/coresetpack/RippedPecs.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/RippedPecs.java
@@ -24,19 +24,20 @@ public class RippedPecs extends AbstractPackmasterCard {
     private boolean synergyOn;
     public RippedPecs() {
         super(ID, 1, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
-        baseMagicNumber = magicNumber = 2;
+        baseMagicNumber = magicNumber = 3;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
         synergyOn = (hasSynergy());
 
-        Wiz.applyToSelfTop(new StrengthPower(p, 1));
         addToBot(new AbstractGameAction() {
             @Override
             public void update() {
                 isDone = true;
                 if (synergyOn) {
                     Wiz.applyToSelfTop(new StrengthPower(p, magicNumber));
+                } else {
+                    Wiz.applyToSelfTop(new StrengthPower(p, 1));
                 }
             }
         });

--- a/src/main/java/thePackmaster/cards/coresetpack/Showoff.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/Showoff.java
@@ -10,11 +10,10 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public class Showoff extends AbstractPackmasterCard {
     public final static String ID = makeID("Showoff");
-    // intellij stuff skill, self, basic, , ,  5, 3, ,
 
     public Showoff() {
         super(ID, 2, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.SELF);
-        baseBlock = 14;
+        baseBlock = 13;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/coresetpack/SmithingHammer.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/SmithingHammer.java
@@ -3,42 +3,39 @@ package thePackmaster.cards.coresetpack;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.UpgradeRandomCardAction;
 import com.megacrit.cardcrawl.actions.utility.WaitAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.vfx.UpgradeShineEffect;
 import thePackmaster.cards.AbstractPackmasterCard;
 import thePackmaster.util.Wiz;
+import thePackmaster.vfx.coresetpack.UpgradeShineEffectSingleHit;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 import static thePackmaster.util.Wiz.atb;
 
 public class SmithingHammer extends AbstractPackmasterCard {
     public final static String ID = makeID("SmithingHammer");
-    // intellij stuff attack, enemy, basic, 6, 3,  , , ,
 
     public SmithingHammer() {
         super(ID, 1, CardType.ATTACK, CardRarity.COMMON, CardTarget.ENEMY);
         baseDamage = 3;
-        baseMagicNumber = magicNumber = 1;
+        baseMagicNumber = magicNumber = 2;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
-        Wiz.vfx(new UpgradeShineEffect(m.hb.cX, m.hb.cY));
-        atb(new WaitAction(0.1f));
-        atb(new WaitAction(0.1f));
-        dmg(m, AbstractGameAction.AttackEffect.NONE);
-        atb(new WaitAction(0.1f));
-        dmg(m, AbstractGameAction.AttackEffect.NONE);
-        atb(new WaitAction(0.1f));
-        dmg(m, AbstractGameAction.AttackEffect.NONE);
-        atb(new WaitAction(0.1f));
         for (int i = 0; i < magicNumber; i++) {
-            this.addToBot(new UpgradeRandomCardAction());
+            Wiz.vfx(new UpgradeShineEffectSingleHit(m.hb.cX, m.hb.cY));
+            dmg(m, AbstractGameAction.AttackEffect.NONE);
+            atb(new WaitAction(0.1f));
         }
+        atb(new WaitAction(0.1f));
+
+        this.addToBot(new UpgradeRandomCardAction());
+        this.addToBot(new UpgradeRandomCardAction());
     }
 
     public void upp() {
-        upgradeDamage(1);
         upgradeMagicNumber(1);
     }
 }

--- a/src/main/java/thePackmaster/cards/coresetpack/Synergize.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/Synergize.java
@@ -13,8 +13,8 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public class Synergize extends AbstractPackmasterCard {
     public final static String ID = makeID("Synergize");
-    // intellij stuff skill, self, basic, , ,  5, 3, ,
 
+    private boolean synergyOn;
     public Synergize() {
         super(ID, 1, CardType.ATTACK, CardRarity.COMMON, CardTarget.ALL_ENEMY);
         baseBlock = 7;
@@ -23,12 +23,13 @@ public class Synergize extends AbstractPackmasterCard {
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
+        synergyOn = (hasSynergy());
         allDmg(AbstractGameAction.AttackEffect.LIGHTNING);
         addToBot(new AbstractGameAction() {
             @Override
             public void update() {
                 isDone = true;
-                if (otherPacksInHandCheck()) {
+                if (synergyOn) {
                     blck();
                 }
             }
@@ -38,19 +39,11 @@ public class Synergize extends AbstractPackmasterCard {
     @Override
     public void triggerOnGlowCheck() {
         this.glowColor = AbstractCard.BLUE_BORDER_GLOW_COLOR.cpy();
-        if (this.otherPacksInHandCheck()) {
+        if (hasSynergy()) {
             this.glowColor = AbstractCard.GOLD_BORDER_GLOW_COLOR.cpy();
         }
     }
 
-    private boolean otherPacksInHandCheck() {
-        long otherPacksInHand = AbstractDungeon.player.hand.group.stream()
-                .map(c -> SpireAnniversary5Mod.cardParentMap.getOrDefault(c.cardID, null))
-                .filter(s -> s != null && !s.equals(CoreSetPack.ID))
-                .distinct()
-                .count();
-        return otherPacksInHand >= 2;
-    }
 
     @Override
     public void upp() {

--- a/src/main/java/thePackmaster/vfx/coresetpack/UpgradeShineEffectSingleHit.java
+++ b/src/main/java/thePackmaster/vfx/coresetpack/UpgradeShineEffectSingleHit.java
@@ -1,0 +1,48 @@
+
+package thePackmaster.vfx.coresetpack;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.MathUtils;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.ScreenShake.ShakeDur;
+import com.megacrit.cardcrawl.helpers.ScreenShake.ShakeIntensity;
+import com.megacrit.cardcrawl.random.Random;
+import com.megacrit.cardcrawl.vfx.AbstractGameEffect;
+import com.megacrit.cardcrawl.vfx.UpgradeHammerImprintEffect;
+import com.megacrit.cardcrawl.vfx.UpgradeShineParticleEffect;
+
+public class UpgradeShineEffectSingleHit extends AbstractGameEffect {
+    private float x;
+    private float y;
+
+    private Random rng = new Random();
+    public UpgradeShineEffectSingleHit(float x, float y) {
+        this.x = x;
+        this.y = y;
+        this.duration = 0.2F;
+    }
+
+    public void update() {
+            CardCrawlGame.sound.play("UpgradesPack_ShortUpgrade");
+            clank(this.x - (rng.random(-60F,60F)) * Settings.scale, this.y + (rng.random(-90F,90F) * Settings.scale));
+            this.isDone = true;
+    }
+
+    private void clank(float x, float y) {
+        AbstractDungeon.topLevelEffectsQueue.add(new UpgradeHammerImprintEffect(x, y));
+        if (!Settings.DISABLE_EFFECTS) {
+            for(int i = 0; i < 30; ++i) {
+                AbstractDungeon.topLevelEffectsQueue.add(new UpgradeShineParticleEffect(x + MathUtils.random(-10.0F, 10.0F) * Settings.scale, y + MathUtils.random(-10.0F, 10.0F) * Settings.scale));
+            }
+
+        }
+    }
+
+    public void render(SpriteBatch sb) {
+    }
+
+    public void dispose() {
+    }
+}

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
@@ -1,7 +1,7 @@
 {
   "${ModID}:BackpackSmack": {
     "NAME": "Backpack Smack",
-    "DESCRIPTION": "Deal !D! damage. NL If your draw pile has 10 or more cards, draw !M! cards. NL Otherwise, gain [E] ."
+    "DESCRIPTION": "Deal !D! damage X times. NL ${ModID}:Synergy: Gain [E] ."
   },
   "${ModID}:BoosterTutor": {
     "NAME": "Booster Tutor",
@@ -9,7 +9,7 @@
   },
   "${ModID}:DestinyDraw": {
     "NAME": "Destiny Draw",
-    "DESCRIPTION": "Choose 1 of 3 random cards from different Packs to add to your hand. NL It costs 0 this turn. NL Exhaust."
+    "DESCRIPTION": "Choose 1 of 3 cards from different Packs to add to your hand. It costs 0 this turn. NL Exhaust."
   },
   "${ModID}:Flick": {
     "NAME": "Flick",
@@ -22,9 +22,7 @@
   },
   "${ModID}:RippedPecs": {
     "NAME": "Ripped Pecs",
-    "DESCRIPTION": "Gain 1 Strength for each Pack you've played a card from this combat. NL Exhaust.",
-    "UPGRADE_DESCRIPTION": "Gain 1 Strength for each Pack you've played a card from this combat.",
-    "EXTENDED_DESCRIPTION": [" NL (Gains {0} Strength.)"]
+    "DESCRIPTION": "Gain 1 Strength. NL ${ModID}:Synergy: Gain !M! Strength."
   },
   "${ModID}:Showoff": {
     "NAME": "Showoff",
@@ -36,11 +34,10 @@
   },
   "${ModID}:SmithingHammer": {
     "NAME": "Smithing Hammer",
-    "DESCRIPTION": "Deal !D! damage 3 times. NL Upgrade a random card in your hand for the rest of combat.",
-    "UPGRADE_DESCRIPTION": "Deal !D! damage 3 times. NL Upgrade !M! random cards in your hand for the rest of combat."
+    "DESCRIPTION": "Deal !D! damage !M! times. NL Upgrade 2 random cards in your hand."
   },
   "${ModID}:Synergize": {
     "NAME": "Synergize",
-    "DESCRIPTION": "Deal !D! damage to ALL enemies. NL If you have cards from at least two other Packs in your hand, gain !B! Block."
+    "DESCRIPTION": "Deal !D! damage to ALL enemies. NL ${ModID}:Synergy: Gain !B! Block."
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
@@ -9,7 +9,7 @@
   },
   "${ModID}:DestinyDraw": {
     "NAME": "Destiny Draw",
-    "DESCRIPTION": "Choose 1 of 3 cards from different Packs to add to your hand. It costs 0 this turn. NL Exhaust."
+    "DESCRIPTION": "Choose 1 of 3 random cards from different Packs to add to your hand. It costs 0 this turn. Exhaust."
   },
   "${ModID}:Flick": {
     "NAME": "Flick",

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
@@ -22,7 +22,7 @@
   },
   "${ModID}:RippedPecs": {
     "NAME": "Ripped Pecs",
-    "DESCRIPTION": "Gain 1 Strength. NL ${ModID}:Synergy: Gain !M! Strength."
+    "DESCRIPTION": "Gain 1 Strength. NL ${ModID}:Synergy: Gain !M! Strength instead."
   },
   "${ModID}:Showoff": {
     "NAME": "Showoff",

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Keywordstrings.json
@@ -4,6 +4,6 @@
     "NAMES": [
       "synergy"
     ],
-    "DESCRIPTION": "Additional effect if you have cards from 3 different packs in your hand."
+    "DESCRIPTION": "Additional effect if you have cards from 3 unique packs in your hand."
   }
 ]

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Keywordstrings.json
@@ -4,6 +4,6 @@
     "NAMES": [
       "synergy"
     ],
-    "DESCRIPTION": "Additional effect if you have cards from 3 unique packs in your hand."
+    "DESCRIPTION": "Additional effect if you have cards from 2 other packs in your hand."
   }
 ]

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Keywordstrings.json
@@ -1,2 +1,9 @@
 [
+  {
+    "PROPER_NAME": "Synergy",
+    "NAMES": [
+      "synergy"
+    ],
+    "DESCRIPTION": "Additional effect if you have cards from 3 different packs in your hand."
+  }
 ]

--- a/src/main/resources/anniv5Resources/localization/zhs/coresetpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/zhs/coresetpack/Cardstrings.json
@@ -1,7 +1,7 @@
 {
   "${ModID}:BackpackSmack": {
     "NAME": "背包甩掴",
-    "DESCRIPTION": "造成 !D! 点伤害。 NL 若抽牌堆有10+张牌， NL 抽 !M! 张牌， NL 否则获得 [E] 。"
+    "DESCRIPTION": "Deal !D! damage X times. NL ${ModID}:Synergy: Gain [E] ."
   },
   "${ModID}:BoosterTutor": {
     "NAME": "奇寻卡包",
@@ -22,9 +22,7 @@
   },
   "${ModID}:RippedPecs": {
     "NAME": "腹肌",
-    "DESCRIPTION": "本场战斗每用过一种卡包的牌，获得1点 力量 。 NL 消耗 。",
-    "UPGRADE_DESCRIPTION": "本场战斗每用过一种卡包的牌，获得1点 力量 。",
-    "EXTENDED_DESCRIPTION": [" NL (获得 {0} 点 力量 。)"]
+    "DESCRIPTION": "Gain 1 Strength. NL ${ModID}:Synergy: Gain !M! Strength."
   },
   "${ModID}:Showoff": {
     "NAME": "狂炫",
@@ -36,11 +34,10 @@
   },
   "${ModID}:SmithingHammer": {
     "NAME": "锻造锤击",
-    "DESCRIPTION": "造成 !D! 点伤害3次。 NL 随机 升级 !M! 张手牌。",
-    "UPGRADE_DESCRIPTION": "造成 !D! 点伤害3次。 NL 随机 升级 !M! 张手牌。"
+    "DESCRIPTION": "Deal !D! damage !M! times. NL Upgrade 2 random cards in your hand."
   },
   "${ModID}:Synergize": {
     "NAME": "套路配合",
-    "DESCRIPTION": "对所有敌人造成 !D! 点伤害。 NL 若手中至少有2种其他卡包的牌，获得 !B! 点 格挡 。"
+    "DESCRIPTION": "Deal !D! damage to ALL enemies. NL ${ModID}:Synergy: Gain !B! Block."
   }
 }

--- a/src/main/resources/anniv5Resources/localization/zhs/coresetpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/zhs/coresetpack/Cardstrings.json
@@ -22,7 +22,7 @@
   },
   "${ModID}:RippedPecs": {
     "NAME": "腹肌",
-    "DESCRIPTION": "Gain 1 Strength. NL ${ModID}:Synergy: Gain !M! Strength."
+    "DESCRIPTION": "Gain 1 Strength. NL ${ModID}:Synergy: Gain !M! Strength instead."
   },
   "${ModID}:Showoff": {
     "NAME": "狂炫",

--- a/src/main/resources/anniv5Resources/localization/zhs/coresetpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/zhs/coresetpack/Keywordstrings.json
@@ -4,6 +4,6 @@
     "NAMES": [
       "synergy"
     ],
-    "DESCRIPTION": "Additional effect if you have cards from 3 different packs in your hand."
+    "DESCRIPTION": "Additional effect if you have cards from 3 unique packs in your hand."
   }
 ]

--- a/src/main/resources/anniv5Resources/localization/zhs/coresetpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/zhs/coresetpack/Keywordstrings.json
@@ -1,2 +1,9 @@
 [
+  {
+    "PROPER_NAME": "Synergy",
+    "NAMES": [
+      "synergy"
+    ],
+    "DESCRIPTION": "Additional effect if you have cards from 3 different packs in your hand."
+  }
 ]


### PR DESCRIPTION
Synergize: Now uses the new "Synergy" keyword, which is the same as the card's previous condition, just wrapped up into a keyword instead of three lines of text.

Backpack Smack: Reworked to be an X-cost card.  Deals 6 damage per energy spent.  Has Synergy: Gain 1 Energy.

Showoff: Block reduced by 1.

Ripped Pecs: Reworked to now gain 1 Strength, plus another 2(3) if you have Synergy.

Smithing Hammer: Damage reduced to 3x2, upgrading to 3 hits on upgrade, but always upgrades 2 random cards instead of 1(2).