### PR TITLE
Core set pack: change synergy effect on Backpack Smack to apply Weak and Vulnerable instead of giving energy

### DIFF
--- a/src/main/java/thePackmaster/cards/coresetpack/BackpackSmack.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/BackpackSmack.java
@@ -1,22 +1,17 @@
 package thePackmaster.cards.coresetpack;
 
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
-import com.megacrit.cardcrawl.actions.common.DrawCardAction;
-import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
-import com.megacrit.cardcrawl.actions.common.MakeTempCardInDrawPileAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
-import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
-import com.megacrit.cardcrawl.powers.StrengthPower;
+import com.megacrit.cardcrawl.powers.VulnerablePower;
+import com.megacrit.cardcrawl.powers.WeakPower;
 import thePackmaster.actions.EasyXCostAction;
 import thePackmaster.cards.AbstractPackmasterCard;
-import thePackmaster.cards.highenergypack.Food;
 import thePackmaster.util.Wiz;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 import static thePackmaster.util.Wiz.atb;
-import static thePackmaster.util.Wiz.att;
 
 public class BackpackSmack extends AbstractPackmasterCard {
     public final static String ID = makeID("BackpackSmack");
@@ -34,23 +29,17 @@ public class BackpackSmack extends AbstractPackmasterCard {
         synergyOn = (hasSynergy());
 
         atb(new EasyXCostAction(this, (effect, params) -> {
+            if (synergyOn && effect > 0) {
+                Wiz.applyToEnemyTop(m, new VulnerablePower(m, effect, false));
+                Wiz.applyToEnemyTop(m, new WeakPower(m, effect, false));
+            }
             for (int i = 0; i < effect; i++) {
                 dmgTop(m, AbstractGameAction.AttackEffect.BLUNT_HEAVY);
             }
             return true;
         }));
-
-        addToBot(new AbstractGameAction() {
-            @Override
-            public void update() {
-                isDone = true;
-                if (synergyOn) {
-                    Wiz.atb(new GainEnergyAction(1));
-                }
-            }
-        });
-
     }
+
     @Override
     public void triggerOnGlowCheck() {
         if (hasSynergy()) {

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
@@ -1,7 +1,7 @@
 {
   "${ModID}:BackpackSmack": {
     "NAME": "Backpack Smack",
-    "DESCRIPTION": "Deal !D! damage X times. NL ${ModID}:Synergy: Gain [E] ."
+    "DESCRIPTION": "Deal !D! damage X times. NL ${ModID}:Synergy: Apply X Weak and Vulnerable."
   },
   "${ModID}:BoosterTutor": {
     "NAME": "Booster Tutor",

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Keywordstrings.json
@@ -4,6 +4,6 @@
     "NAMES": [
       "synergy"
     ],
-    "DESCRIPTION": "Additional effect if you have cards from 2 other packs in your hand."
+    "DESCRIPTION": "Additional effect if you have cards from #b2 other packs in your hand."
   }
 ]


### PR DESCRIPTION
This was the consensus outcome to the discussion around improving the new Backpack Smack. It looks like I joined the conversation about Backpack Smack just as you left, so here's a link to your last message if you wanted to skim things over: https://discord.com/channels/309399445785673728/398373038732738570/1077723474082156564. Vex suggested applying weak and vulnerable, I made a simplified version of that suggestion, and people liked it.

I think it's much more interesting of a card this way, since this design gives you an incentive to play it for higher numbers if you can get the Synergy effect. It's still a bit weak without Synergy, but that's inherent to the design of Synergy cards. Another benefit of this design is that the core set pack now has some weak and vulnerable in it.

I briefly thought about having the upgrade change X to X + 1, but quickly realized that was a bad idea. It would let you play this as 6 damage/1 weak/1 vuln for 0 energy, which is a bit too much. Of course, Chemical X lets you do an even better version of that, but all X cost cards are amazing at 0 energy with Chemical X.

Leaving this for you to merge so that you see the change, given the feedback and discussion around it.