### PR TITLE
fix: Updating Unplayable Card Behavior

### DIFF
--- a/src/main/java/thePackmaster/actions/rippack/RipCardAction.java
+++ b/src/main/java/thePackmaster/actions/rippack/RipCardAction.java
@@ -40,6 +40,8 @@ public class RipCardAction extends AbstractGameAction {
             artCard.rawDescription = "";
             artCard.initializeDescription();
             artCard.target = artCard.cardID == ArtAttack.ID ? artCard.target : AbstractCard.CardTarget.NONE;
+            artCard.cost = rippedCard.cost;
+            artCard.costForTurn = rippedCard.costForTurn;
             AllCardsRippablePatches.AbstractCardFields.ripStatus.set(artCard, AllCardsRippablePatches.RipStatus.ART);
 
             //Set up Text Half properties

--- a/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
+++ b/src/main/java/thePackmaster/patches/rippack/AllCardsRippablePatches.java
@@ -9,12 +9,16 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.evacipated.cardcrawl.mod.stslib.patches.HitboxRightClick;
+import com.evacipated.cardcrawl.modthespire.Loader;
+import com.evacipated.cardcrawl.modthespire.ModInfo;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.animations.VFXAction;
 import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.actions.utility.WaitAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.curses.Normality;
+import com.megacrit.cardcrawl.cards.green.Reflex;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
@@ -24,12 +28,19 @@ import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.CorruptionPower;
 import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
+import javassist.*;
+import org.clapper.util.classutil.*;
 import thePackmaster.actions.rippack.RipCardAction;
 import thePackmaster.cardmodifiers.rippack.ArtCardModifier;
 import thePackmaster.cardmodifiers.rippack.RippableModifier;
 import thePackmaster.cardmodifiers.rippack.TextCardModifier;
 import thePackmaster.cards.rippack.ArtAttack;
+import thePackmaster.util.Wiz;
 import thePackmaster.vfx.rippack.ShowCardAndRipEffect;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
 
 import static thePackmaster.SpireAnniversary5Mod.*;
 import static thePackmaster.cardmodifiers.rippack.RippableModifier.isRippable;
@@ -146,6 +157,103 @@ public class AllCardsRippablePatches {
             return SpireReturn.Continue();
         }
     }
+
+    @SpirePatch(clz = Reflex.class, method = "use")
+    public static class MakeReflexNotHaveAUse {
+
+        @SpirePrefixPatch
+        public static SpireReturn Prefix(AbstractCard __instance, AbstractPlayer p, AbstractMonster m) {
+            if(isTextCard(__instance)) {
+                return SpireReturn.Return(true);
+            } else {
+                return SpireReturn.Continue();
+            }
+        }
+    }
+
+    @SpirePatch(clz = Normality.class, method = "canPlay")
+    public static class MakeArtNormalityDoNothing {
+
+        @SpirePrefixPatch
+        public static SpireReturn Prefix(Normality __instance, AbstractCard card) {
+            if(isArtCard(__instance)) {
+                return SpireReturn.Return(true);
+            } else {
+                return SpireReturn.Continue();
+            }
+        }
+    }
+
+    //Dynamically patch canUse of cards to make Text halves always playable
+    //Dynamically patch a bunch of triggers of cards
+    //This will make things like burn's effect not apply at the end of the players turn if it's an art card
+    @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
+    public static class MakeArtCardsInertLikeDragonballsAndTextCardsAlwaysPlayable {
+        public static void Raw(CtBehavior ctBehavior) throws NotFoundException {
+            ClassFinder finder = new ClassFinder();
+
+            finder.add(new File(Loader.STS_JAR));
+
+            for (ModInfo modInfo : Loader.MODINFOS) {
+                if (modInfo.jarURL != null) {
+                    try {
+                        finder.add(new File(modInfo.jarURL.toURI()));
+                    } catch (URISyntaxException e) {
+                        // do nothing
+                    }
+                }
+            }
+
+            // Get all classes for AbstractCard
+            ClassFilter filter = new AndClassFilter(
+                    new NotClassFilter(new InterfaceOnlyClassFilter()),
+                    new ClassModifiersClassFilter(Modifier.PUBLIC),
+                    new OrClassFilter(
+                            new org.clapper.util.classutil.SubclassClassFilter(AbstractCard.class),
+                            (classInfo, classFinder) -> classInfo.getClassName().equals(AbstractCard.class.getName())
+                    )
+            );
+
+            ArrayList<ClassInfo> foundClasses = new ArrayList<>();
+            finder.findClasses(foundClasses, filter);
+
+            for (ClassInfo classInfo : foundClasses) {
+                CtClass ctClass = ctBehavior.getDeclaringClass().getClassPool().get(classInfo.getClassName());
+
+                try {
+                    CtMethod[] methods = ctClass.getDeclaredMethods();
+                    for (CtMethod m : methods) {
+                        if (m.getName().equals("triggerOnEndOfTurnForPlayingCard") ||
+                                m.getName().equals("triggerOnManualDiscard") ||
+                                m.getName().equals("triggerOnExhaust") ||
+                                m.getName().equals("triggerOnScry") ||
+                                m.getName().equals("triggerOnOtherCardPlayed") ||
+                                m.getName().equals("onRetained")) {
+
+                            m.insertBefore("{" +
+                                    "if(" + MakeArtCardsInertLikeDragonballsAndTextCardsAlwaysPlayable.class.getName() + ".isArtCard($0)) { " +
+                                    "return;}}");
+                        }
+                        if (m.getName().equals("canUse")) {
+                            m.insertBefore("{" +
+                                    "if(" + MakeArtCardsInertLikeDragonballsAndTextCardsAlwaysPlayable.class.getName() + ".isTextCard($0)) { " +
+                                    "return true;}}");
+                        }
+                    }
+                } catch (CannotCompileException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        public static boolean isArtCard(AbstractCard card) {
+            return Wiz.isArtCard(card);
+        }
+        public static boolean isTextCard(AbstractCard card) {
+            return Wiz.isTextCard(card);
+        }
+    }
+
     public static boolean setShader = false;
 
     //I only want my patch in renderHelper below to apply on card backgrounds


### PR DESCRIPTION
Unplayable cards now behave as follows:
Text half - always playable, any other effects on the card will work as if it was the normal card (ex. Normality limiting cards playable per turn to three) 
Art half - Keeps the playability of the original card, but doesn't do anything else. So the art half of a Burn won't be playable, but also won't damage you at the end of the turn