### PR TITLE
Remember whether custom draft was selected between sessions, fix Piratify bug

### DIFF
--- a/src/main/java/thePackmaster/SpireAnniversary5Mod.java
+++ b/src/main/java/thePackmaster/SpireAnniversary5Mod.java
@@ -295,6 +295,7 @@ public class SpireAnniversary5Mod implements
 
         try {
             Properties defaults = new Properties();
+            defaults.put("PackmasterCustomDraftEnabled", "FALSE");
             defaults.put("PackmasterCustomDraftSelection", String.join(",", makeID("CoreSetPack"), RANDOM, RANDOM, RANDOM, CHOICE, CHOICE, CHOICE));
             defaults.put("PackmasterUnlockedHats", "");
             defaults.put("PackmasterAllPacksMode", "FALSE");
@@ -308,6 +309,21 @@ public class SpireAnniversary5Mod implements
             loadModConfigData();
         } catch (Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    public static boolean getCustomDraftEnabled() {
+        if (modConfig == null) return false;
+        return modConfig.getBool("PackmasterCustomDraftEnabled");
+    }
+
+    public static void saveCustomDraftEnabled(boolean enabled) {
+        try {
+            if (modConfig == null) return;
+            modConfig.setBool("PackmasterCustomDraftEnabled", enabled);
+            modConfig.save();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/thePackmaster/cardmodifiers/madsciencepack/GainCannonballModifier.java
+++ b/src/main/java/thePackmaster/cardmodifiers/madsciencepack/GainCannonballModifier.java
@@ -36,7 +36,7 @@ public class GainCannonballModifier extends AbstractMadScienceModifier {
     @Override
     public void onInitialApplication(AbstractCard card) {
         super.onInitialApplication(card);
-        if (card.cardsToPreview != null) {
+        if (card.cardsToPreview == null) {
             AbstractCard c = new Cannonball();
             if (value>0) c.upgrade();
             card.cardsToPreview = c;

--- a/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
+++ b/src/main/java/thePackmaster/patches/MainMenuUIPatch.java
@@ -26,7 +26,7 @@ import java.util.*;
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public class MainMenuUIPatch {
-    public static boolean customDraft = false;
+    public static boolean customDraft;
 
     private static final Hitbox packDraftToggle = new Hitbox(40.0f * Settings.scale, 40.0f * Settings.scale);
     private static final UIStrings uiStrings = CardCrawlGame.languagePack.getUIString(makeID("PackMainMenuUI"));
@@ -88,6 +88,8 @@ public class MainMenuUIPatch {
             optionIDs[i] = packID;
             idToIndex.put(packID, i);
         }
+
+        customDraft = SpireAnniversary5Mod.getCustomDraftEnabled();
 
         //Validate the saved CDraftSelection - this is necessary in the event that any packs are removed.
         //Without this validation, Packmaster will crash on attempting to load a Pack that is no longer in the pack list.
@@ -231,6 +233,7 @@ public class MainMenuUIPatch {
                         }
                         if (packDraftToggle.clicked) {
                             customDraft = !customDraft;
+                            SpireAnniversary5Mod.saveCustomDraftEnabled(customDraft);
                             packDraftToggle.clicked = false;
                         }
                     }


### PR DESCRIPTION
Leaving this up for you to merge so that you can see the new config field. The state of the custom draft checkbox should've been saved all along but I guess we overlooked it.

The Piratify bug was causing cards from the Quiet pack to produce Cannonballs instead of Weights when Piratify was used on them, because the condition for Piratify was the opposite of what it should have been. Also due to this fix, Piratify will now show Cannonballs as the preview card for anything that didn't already have a preview card, like it was supposed to all along.