### PR TITLE
already calculates block properly in apply powers

### DIFF
--- a/src/main/java/thePackmaster/cards/intriguepack/Exultation.java
+++ b/src/main/java/thePackmaster/cards/intriguepack/Exultation.java
@@ -18,25 +18,18 @@ public class Exultation extends AbstractIntrigueCard {
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
-        this.applyPowers();
         Wiz.atb(new AbstractGameAction() {
             @Override
             public void update() {
-                int blk = 0;
-
                 for(AbstractCard c : Wiz.p().hand.group)
                 {
                     if (c != Exultation.this)
-                    if (promote(c))
-                        blk += magicNumber;
+                        promote(c);
                 }
-
-                if (blk > 0)
-                Wiz.doBlk(magicNumber);
-
                 isDone = true;
             }
         });
+        blck();
     }
 
     public void applyPowers() {


### PR DESCRIPTION
exultation used Wiz.doBlk(magicNumber); instead of the block value calculated in use

it also just calculated it in applyPowers and current code would have resulting in not applying dex/other stuff even though value on card does

so now it just uses the displayed value which is correct anyways