### PR TITLE
Compendium: organize the Packmaster's compendium tab to cleanly show each pack in two rows of five cards

### DIFF
--- a/src/main/java/thePackmaster/patches/CompendiumPatches.java
+++ b/src/main/java/thePackmaster/patches/CompendiumPatches.java
@@ -1,10 +1,13 @@
 package thePackmaster.patches;
 
 import basemod.ReflectionHacks;
+import basemod.patches.com.megacrit.cardcrawl.screens.compendium.CardLibraryScreen.EverythingFix;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.helpers.Hitbox;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.screens.compendium.CardLibSortHeader;
@@ -14,9 +17,12 @@ import javassist.CtBehavior;
 import javassist.expr.ExprEditor;
 import javassist.expr.NewExpr;
 import thePackmaster.SpireAnniversary5Mod;
+import thePackmaster.ThePackmaster;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class CompendiumPatches {
     public static UIStrings uiStrings = CardCrawlGame.languagePack.getUIString(SpireAnniversary5Mod.makeID("Compendium"));
@@ -129,6 +135,21 @@ public class CompendiumPatches {
                                     .thenComparing(o -> ((AbstractCard) o).name)
                     )
             );
+        }
+    }
+
+    @SpirePatch2(clz = EverythingFix.Initialize.class, method = "Insert")
+    public static class ShowBaseGameCards {
+        @SpirePostfixPatch
+        public static void showBaseGameCards(Object __obj_instance) {
+            if (EverythingFix.Fields.cardGroupMap.containsKey(ThePackmaster.Enums.PACKMASTER_RAINBOW)) {
+                CardGroup group = EverythingFix.Fields.cardGroupMap.get(ThePackmaster.Enums.PACKMASTER_RAINBOW);
+                List<AbstractCard> baseGameCards = CardLibrary.getAllCards().stream()
+                        .filter(c -> (c.color == AbstractCard.CardColor.RED || c.color == AbstractCard.CardColor.GREEN || c.color == AbstractCard.CardColor.BLUE || c.color == AbstractCard.CardColor.PURPLE))
+                        .filter(c -> SpireAnniversary5Mod.cardParentMap.containsKey(c.cardID))
+                        .collect(Collectors.toList());
+                group.group.addAll(baseGameCards);
+            }
         }
     }
 }

--- a/src/main/java/thePackmaster/patches/CompendiumPatches.java
+++ b/src/main/java/thePackmaster/patches/CompendiumPatches.java
@@ -11,6 +11,7 @@ import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.helpers.Hitbox;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.screens.compendium.CardLibSortHeader;
+import com.megacrit.cardcrawl.screens.compendium.CardLibraryScreen;
 import com.megacrit.cardcrawl.screens.mainMenu.SortHeaderButton;
 import javassist.CannotCompileException;
 import javassist.CtBehavior;
@@ -149,6 +150,15 @@ public class CompendiumPatches {
                         .filter(c -> SpireAnniversary5Mod.cardParentMap.containsKey(c.cardID))
                         .collect(Collectors.toList());
                 group.group.addAll(baseGameCards);
+
+                // We've found that having the special rarity cards associated with the packs show up in the Packmaster's
+                // tab is not very useful, and we want to have each pack of 10 cards in two nicely organized rows (when
+                // sorted by packs). In the future we might make all these cards colorless (and remove or change this code),
+                // but for now we just move them to the list that the compendium uses for colorless cards
+                List<AbstractCard> specialRarityCards = group.group.stream().filter(c -> c.rarity == AbstractCard.CardRarity.SPECIAL).collect(Collectors.toList());
+                CardGroup colorlessCards = ReflectionHacks.getPrivate(__obj_instance, CardLibraryScreen.class, "colorlessCards");
+                colorlessCards.group.addAll(specialRarityCards);
+                group.group.removeIf(c -> c.rarity == AbstractCard.CardRarity.SPECIAL);
             }
         }
     }

--- a/src/main/java/thePackmaster/patches/RenderBaseGameCardPackTopTextPatches.java
+++ b/src/main/java/thePackmaster/patches/RenderBaseGameCardPackTopTextPatches.java
@@ -1,26 +1,31 @@
 package thePackmaster.patches;
 
+import basemod.ReflectionHacks;
+import basemod.patches.com.megacrit.cardcrawl.screens.mainMenu.ColorTabBar.ColorTabBarFix;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.screens.compendium.CardLibraryScreen;
+import com.megacrit.cardcrawl.screens.mainMenu.ColorTabBar;
+import com.megacrit.cardcrawl.screens.mainMenu.MainMenuScreen;
 import thePackmaster.ThePackmaster;
 import thePackmaster.cards.AbstractPackmasterCard;
 import thePackmaster.packs.AbstractCardPack;
 import thePackmaster.util.Wiz;
 
 @SpirePatch2(clz = AbstractCard.class, method = "render", paramtypez = {SpriteBatch.class})
+@SpirePatch2(clz = AbstractCard.class, method = "renderInLibrary", paramtypez = {SpriteBatch.class})
 public class RenderBaseGameCardPackTopTextPatches {
     @SpirePostfixPatch
     public static void patch(AbstractCard __instance, SpriteBatch sb) {
-        if(!Settings.hideCards && AbstractDungeon.player != null &&
-                AbstractDungeon.player.chosenClass == ThePackmaster.Enums.THE_PACKMASTER && __instance.getClass().getSuperclass().equals(AbstractCard.class)) {
+        if(shouldShowPackName(__instance)) {
             AbstractCardPack pack = Wiz.getPackByCard(__instance);
             if (pack != null) {
                 float xPos, yPos, offsetY;
@@ -48,5 +53,26 @@ public class RenderBaseGameCardPackTopTextPatches {
                 fontData.setScale(originalScale);
             }
         }
+    }
+
+    public static boolean shouldShowPackName(AbstractCard c) {
+        return !Settings.hideCards
+                && c.getClass().getSuperclass().equals(AbstractCard.class)
+                && (isInPackmasterRun() || isInPackmasterCardLibraryScreen());
+    }
+
+    private static boolean isInPackmasterRun() {
+        return AbstractDungeon.player != null && AbstractDungeon.player.chosenClass == ThePackmaster.Enums.THE_PACKMASTER;
+    }
+
+    private static boolean isInPackmasterCardLibraryScreen() {
+        if (AbstractDungeon.player == null && CardCrawlGame.mainMenuScreen.screen == MainMenuScreen.CurScreen.CARD_LIBRARY) {
+            ColorTabBar colorBar = ReflectionHacks.getPrivate(CardCrawlGame.mainMenuScreen.cardLibraryScreen, CardLibraryScreen.class, "colorBar");
+            if (colorBar.curTab == ColorTabBarFix.Enums.MOD) {
+                ColorTabBarFix.ModColorTab modColorTab = ColorTabBarFix.Fields.getModTab();
+                return modColorTab != null && modColorTab.color == ThePackmaster.Enums.PACKMASTER_RAINBOW;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/thePackmaster/patches/SingleCardViewBorderTextPatch.java
+++ b/src/main/java/thePackmaster/patches/SingleCardViewBorderTextPatch.java
@@ -39,7 +39,7 @@ public class SingleCardViewBorderTextPatch {
             AbstractCard card = (AbstractCard)cardField.get(__instance);
             if (card instanceof AbstractPackmasterCard) {
                 ((AbstractPackmasterCard)card).renderBorderText(sb, Settings.WIDTH / 2.0F, (float)yField.get(__instance), yOffsetBase, drawScale);
-            } else if (AbstractDungeon.player != null && AbstractDungeon.player.chosenClass == ThePackmaster.Enums.THE_PACKMASTER && card.getClass().getSuperclass().equals(AbstractCard.class)) {
+            } else if (RenderBaseGameCardPackTopTextPatches.shouldShowPackName(card)) {
                 AbstractCardPack pack = Wiz.getPackByCard(card);
                 if (pack != null) {
                     float xPos, yPos, offsetY;


### PR DESCRIPTION
To understand what's going on with the code I wrote you'll need to look at https://github.com/daviscook477/BaseMod/blob/1a8a344ecfde07613d29f39ff52b380cf50196f9/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/compendium/CardLibraryScreen/EverythingFix.java and https://github.com/daviscook477/BaseMod/blob/1a8a344ecfde07613d29f39ff52b380cf50196f9/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/mainMenu/ColorTabBar/ColorTabBarFix.java. The compendium tab for modded characters only exists in BaseMod, so most of what I've written is patches on top of BaseMod's patches combined with a bit of digging into the internals of CardLibraryScreen.