### PR TITLE
Mad Science pack: fix Cheapen's Amplify to actually prevent it from exhausting

### DIFF
--- a/src/main/java/thePackmaster/actions/ChangePlayedCardExhaustAction.java
+++ b/src/main/java/thePackmaster/actions/ChangePlayedCardExhaustAction.java
@@ -1,0 +1,29 @@
+package thePackmaster.actions;
+
+import basemod.ReflectionHacks;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.utility.UseCardAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+
+public class ChangePlayedCardExhaustAction extends AbstractGameAction {
+    private final AbstractCard card;
+    private final boolean exhaust;
+
+    public ChangePlayedCardExhaustAction(AbstractCard card, boolean exhaust) {
+        this.card = card;
+        this.exhaust = exhaust;
+    }
+
+    @Override
+    public void update() {
+        for (AbstractGameAction a : AbstractDungeon.actionManager.actions) {
+            if (a instanceof UseCardAction) {
+                if (ReflectionHacks.getPrivate(a, UseCardAction.class, "targetCard") == card) {
+                    ((UseCardAction) a).exhaustCard = this.exhaust;
+                }
+            }
+        }
+        this.isDone = true;
+    }
+}

--- a/src/main/java/thePackmaster/cards/basicspack/BackToBasic.java
+++ b/src/main/java/thePackmaster/cards/basicspack/BackToBasic.java
@@ -7,6 +7,7 @@ import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thePackmaster.actions.ChangePlayedCardExhaustAction;
 import thePackmaster.cards.AbstractPackmasterCard;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -22,11 +23,7 @@ public class BackToBasic extends AbstractPackmasterCard {
     public void use(AbstractPlayer p, AbstractMonster m) {
         addToBot(new FetchAction(p.discardPile, 1, (cards)->{
             if(!cards.isEmpty() && cards.get(0).rarity != CardRarity.BASIC) {
-                for (AbstractGameAction a : AbstractDungeon.actionManager.actions)
-                    if (a instanceof UseCardAction) {
-                        if (BackToBasic.this.equals(ReflectionHacks.getPrivate(a, UseCardAction.class, "targetCard")))
-                            ((UseCardAction) a).exhaustCard = true;
-                    }
+                this.addToTop(new ChangePlayedCardExhaustAction(this, true));
             }
         }));
 

--- a/src/main/java/thePackmaster/cards/madsciencepack/Cheapen.java
+++ b/src/main/java/thePackmaster/cards/madsciencepack/Cheapen.java
@@ -1,17 +1,13 @@
 package thePackmaster.cards.madsciencepack;
 
-import com.megacrit.cardcrawl.actions.AbstractGameAction;
-import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
-import thePackmaster.actions.DelayActionAction;
+import thePackmaster.actions.ChangePlayedCardExhaustAction;
 import thePackmaster.actions.madsciencepack.FindCardForAddModifierAction;
 import thePackmaster.cardmodifiers.madsciencepack.CheapenModifier;
-import thePackmaster.cards.AbstractPackmasterCard;
 import thePackmaster.cards.marisapack.AmplifyCard;
 import thePackmaster.util.Wiz;
-import thePackmaster.cards.madsciencepack.AbstractMadScienceCard;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
@@ -39,15 +35,7 @@ public class Cheapen extends AbstractMadScienceCard implements AmplifyCard {
 
     @Override
     public void useAmplified(AbstractPlayer p, AbstractMonster m) {
-        exhaust = false;
-        //Add a delayed action that sets exhaust to true again after the UseCardAction has run through
-        Wiz.atb(new DelayActionAction(new AbstractGameAction() {
-            @Override
-            public void update() {
-                Cheapen.this.exhaust = true;
-                isDone = true;
-            }
-        }));
+        Wiz.atb(new ChangePlayedCardExhaustAction(this, false));
     }
 
     @Override

--- a/src/main/java/thePackmaster/cards/prismaticpack/PrismaticBarrier.java
+++ b/src/main/java/thePackmaster/cards/prismaticpack/PrismaticBarrier.java
@@ -13,6 +13,7 @@ import com.megacrit.cardcrawl.localization.CardStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.PlatedArmorPower;
 import thePackmaster.SpireAnniversary5Mod;
+import thePackmaster.actions.ChangePlayedCardExhaustAction;
 import thePackmaster.cards.AbstractPackmasterCard;
 
 public class PrismaticBarrier extends AbstractPrismaticCard {
@@ -41,20 +42,7 @@ public class PrismaticBarrier extends AbstractPrismaticCard {
         this.addToBot(new GainBlockAction(p, this.block));
         if (this.playedDifferentColorCardCheck()) {
             this.addToBot(new ApplyPowerAction(p, p, new PlatedArmorPower(p, this.magicNumber)));
-            this.addToBot(new AbstractGameAction() {
-                @Override
-                public void update() {
-                    for (AbstractGameAction a : AbstractDungeon.actionManager.actions) {
-                        if (a instanceof UseCardAction) {
-                            if (ReflectionHacks.getPrivate(a, UseCardAction.class, "targetCard") == card) {
-                                ((UseCardAction) a).exhaustCard = true;
-                                break;
-                            }
-                        }
-                    }
-                    this.isDone = true;
-                }
-            });
+            this.addToBot(new ChangePlayedCardExhaustAction(this, true));
         }
     }
 


### PR DESCRIPTION
And switch it and other effects that change whether the currently played card exhausts to all share code.