### PR TITLE
fix voracious sigil + x costs

### DIFF
--- a/src/main/java/thePackmaster/actions/anomalypack/VoraciousSigilAction.java
+++ b/src/main/java/thePackmaster/actions/anomalypack/VoraciousSigilAction.java
@@ -3,6 +3,7 @@ package thePackmaster.actions.anomalypack;
 import basemod.helpers.CardModifierManager;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.ExhaustSpecificCardAction;
+import com.megacrit.cardcrawl.actions.utility.NewQueueCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.Settings;
@@ -27,7 +28,7 @@ public class VoraciousSigilAction extends AbstractGameAction {
             AbstractCard card = this.p.hand.getRandomCard(AbstractCard.CardType.SKILL, true);
             Wiz.atb(new ExhaustSpecificCardAction(card, p.hand));
             CardModifierManager.addModifier(sigil, new SigilModifier(card));
-            Wiz.atb(new RepeatCardAction(card));
+            addToBot(new NewQueueCardAction(card.makeSameInstanceOf(), true, false, true));
         }
         this.isDone = true;
     }

--- a/src/main/java/thePackmaster/actions/anomalypack/VoraciousSigilAction.java
+++ b/src/main/java/thePackmaster/actions/anomalypack/VoraciousSigilAction.java
@@ -28,7 +28,7 @@ public class VoraciousSigilAction extends AbstractGameAction {
             AbstractCard card = this.p.hand.getRandomCard(AbstractCard.CardType.SKILL, true);
             Wiz.atb(new ExhaustSpecificCardAction(card, p.hand));
             CardModifierManager.addModifier(sigil, new SigilModifier(card));
-            addToBot(new NewQueueCardAction(card.makeSameInstanceOf(), true, false, true));
+            addToBot(new NewQueueCardAction(card.makeSameInstanceOf(), true, true, true));
         }
         this.isDone = true;
     }

--- a/src/main/java/thePackmaster/cardmodifiers/anomalypack/SigilModifier.java
+++ b/src/main/java/thePackmaster/cardmodifiers/anomalypack/SigilModifier.java
@@ -1,13 +1,18 @@
 package thePackmaster.cardmodifiers.anomalypack;
 
 import basemod.abstracts.AbstractCardModifier;
+import basemod.helpers.CardModifierManager;
+import basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.MultiCardPreview;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction;
+import com.megacrit.cardcrawl.actions.utility.NewQueueCardAction;
 import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.actions.RepeatCardAction;
+import thePackmaster.cardmodifiers.frostpack.FrozenMod;
 import thePackmaster.cardmodifiers.madsciencepack.AbstractMadScienceModifier;
 import thePackmaster.util.Wiz;
 
@@ -23,31 +28,30 @@ public class SigilModifier extends AbstractCardModifier {
 
     public SigilModifier(AbstractCard absorbed) {
         super();
-        toPlayCard = absorbed;
+        toPlayCard = absorbed.makeSameInstanceOf();
     }
 
-    //TODO: For reasons I don't know, this doesn't actually add the card preview.  Maybe happening too early in the stack, that toPlayCard is still null. Commenting out for now.
-    /*
     public void onInitialApplication(AbstractCard card) {
-        super.onInitialApplication(card);
-        if (card.cardsToPreview == null){
-            card.cardsToPreview = toPlayCard;
-        }
-
+        MultiCardPreview.add(card, toPlayCard);
     }
-
-     */
 
     @Override
     public void onExhausted(AbstractCard card) {
-        super.onExhausted(card);
         Wiz.atb(new MakeTempCardInHandAction(toPlayCard.makeStatEquivalentCopy()));
+        Wiz.atb(new AbstractGameAction() {
+            @Override
+            public void update() {
+                this.isDone = true;
+                CardModifierManager.removeSpecificModifier(card, SigilModifier.this, true);
+            }
+        });
     }
 
     @Override
     public void onUse(AbstractCard card, AbstractCreature target, UseCardAction action) {
-     
-        Wiz.atb(new RepeatCardAction(toPlayCard));
+        AbstractCard cpy = toPlayCard.makeSameInstanceOf();
+        cpy.purgeOnUse = true;
+        Wiz.atb(new NewQueueCardAction(cpy, true, false, true));
     }
 
     @Override

--- a/src/main/java/thePackmaster/cardmodifiers/madsciencepack/AbstractMadScienceModifier.java
+++ b/src/main/java/thePackmaster/cardmodifiers/madsciencepack/AbstractMadScienceModifier.java
@@ -24,9 +24,4 @@ public abstract class AbstractMadScienceModifier extends AbstractCardModifier {
     public void onInitialApplication(AbstractCard card) {
         card.tags.add(SpireAnniversary5Mod.ISCARDMODIFIED);
     }
-
-    @Override
-    public void onRemove(AbstractCard card) {
-
-    }
 }

--- a/src/main/java/thePackmaster/cardmodifiers/madsciencepack/AbstractMadScienceModifier.java
+++ b/src/main/java/thePackmaster/cardmodifiers/madsciencepack/AbstractMadScienceModifier.java
@@ -23,7 +23,10 @@ public abstract class AbstractMadScienceModifier extends AbstractCardModifier {
     @Override
     public void onInitialApplication(AbstractCard card) {
         card.tags.add(SpireAnniversary5Mod.ISCARDMODIFIED);
-        modifyName(card.name, card);
     }
 
+    @Override
+    public void onRemove(AbstractCard card) {
+
+    }
 }

--- a/src/main/java/thePackmaster/cardmodifiers/madsciencepack/AbstractMadScienceModifierWithName.java
+++ b/src/main/java/thePackmaster/cardmodifiers/madsciencepack/AbstractMadScienceModifierWithName.java
@@ -1,8 +1,6 @@
 package thePackmaster.cardmodifiers.madsciencepack;
 
-import basemod.abstracts.AbstractCardModifier;
 import com.megacrit.cardcrawl.cards.AbstractCard;
-import thePackmaster.SpireAnniversary5Mod;
 
 public abstract class AbstractMadScienceModifierWithName extends AbstractMadScienceModifier {
 
@@ -12,12 +10,6 @@ public abstract class AbstractMadScienceModifierWithName extends AbstractMadScie
 
     public AbstractMadScienceModifierWithName(){
         this.value = 0;
-    }
-
-    @Override
-    public void onInitialApplication(AbstractCard card) {
-        super.onInitialApplication(card);
-        modifyName(card.name, card);
     }
 
     @Override

--- a/src/main/java/thePackmaster/cardmodifiers/madsciencepack/PlayCardModifier.java
+++ b/src/main/java/thePackmaster/cardmodifiers/madsciencepack/PlayCardModifier.java
@@ -1,19 +1,24 @@
 package thePackmaster.cardmodifiers.madsciencepack;
 
 import basemod.abstracts.AbstractCardModifier;
+import basemod.helpers.CardModifierManager;
+import basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.MultiCardPreview;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction;
+import com.megacrit.cardcrawl.actions.utility.NewQueueCardAction;
 import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.helpers.FontHelper;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.actions.RepeatCardAction;
+import thePackmaster.cardmodifiers.anomalypack.SigilModifier;
 import thePackmaster.util.Wiz;
 
 @AbstractCardModifier.SaveIgnore
 //SaveIgnore necessary due to the presence of AbstractCard. will crash on load without it.
 public class PlayCardModifier extends AbstractMadScienceModifier {
-
     AbstractCard toPlayCard = null;
 
     public PlayCardModifier(int valueIn) {
@@ -22,23 +27,25 @@ public class PlayCardModifier extends AbstractMadScienceModifier {
 
     public PlayCardModifier(int valueIn, AbstractCard absorbed) {
         super(valueIn);
-        toPlayCard = absorbed;
+        toPlayCard = absorbed.makeSameInstanceOf();
     }
-
 
 
     public void onInitialApplication(AbstractCard card) {
         super.onInitialApplication(card);
-        if (card.cardsToPreview == null){
-            card.cardsToPreview = toPlayCard.makeStatEquivalentCopy();
-        }
-
+        MultiCardPreview.add(card, toPlayCard);
     }
 
     @Override
     public void onExhausted(AbstractCard card) {
-        super.onExhausted(card);
         Wiz.atb(new MakeTempCardInHandAction(toPlayCard.makeStatEquivalentCopy()));
+        Wiz.atb(new AbstractGameAction() {
+            @Override
+            public void update() {
+                this.isDone = true;
+                CardModifierManager.removeSpecificModifier(card, PlayCardModifier.this, true);
+            }
+        });
     }
 
     @Override
@@ -48,8 +55,9 @@ public class PlayCardModifier extends AbstractMadScienceModifier {
 
     @Override
     public void onUse(AbstractCard card, AbstractCreature target, UseCardAction action) {
-
-        Wiz.atb(new RepeatCardAction(toPlayCard));
+        AbstractCard cpy = toPlayCard.makeSameInstanceOf();
+        cpy.purgeOnUse = true;
+        Wiz.atb(new NewQueueCardAction(cpy, true, false, true));
     }
 
     @Override

--- a/src/main/java/thePackmaster/cardmodifiers/madsciencepack/PlayCardModifier.java
+++ b/src/main/java/thePackmaster/cardmodifiers/madsciencepack/PlayCardModifier.java
@@ -57,7 +57,7 @@ public class PlayCardModifier extends AbstractMadScienceModifier {
     public void onUse(AbstractCard card, AbstractCreature target, UseCardAction action) {
         AbstractCard cpy = toPlayCard.makeSameInstanceOf();
         cpy.purgeOnUse = true;
-        Wiz.atb(new NewQueueCardAction(cpy, true, false, true));
+        Wiz.atb(new NewQueueCardAction(cpy, true, true, true));
     }
 
     @Override


### PR DESCRIPTION
also remove manual name change call because cardmods handle it already

And remove absorbed card modifers on exhaust because they're getting "un-absorbed"