### PR TITLE
Compendium: hide and disable the sort by pack button on tabs other than the Packmaster

### DIFF
--- a/src/main/java/thePackmaster/patches/RenderBaseGameCardPackTopTextPatches.java
+++ b/src/main/java/thePackmaster/patches/RenderBaseGameCardPackTopTextPatches.java
@@ -65,7 +65,7 @@ public class RenderBaseGameCardPackTopTextPatches {
         return AbstractDungeon.player != null && AbstractDungeon.player.chosenClass == ThePackmaster.Enums.THE_PACKMASTER;
     }
 
-    private static boolean isInPackmasterCardLibraryScreen() {
+    public static boolean isInPackmasterCardLibraryScreen() {
         if (AbstractDungeon.player == null && CardCrawlGame.mainMenuScreen.screen == MainMenuScreen.CurScreen.CARD_LIBRARY) {
             ColorTabBar colorBar = ReflectionHacks.getPrivate(CardCrawlGame.mainMenuScreen.cardLibraryScreen, CardLibraryScreen.class, "colorBar");
             if (colorBar.curTab == ColorTabBarFix.Enums.MOD) {


### PR DESCRIPTION
In between working on other stuff, I realized that the work I'd done for the cleaned up compendium would also let me fix another thing that's always bothered me: the sort by packs button showing up for other tabs in the compendium. I think nobody really wanted to implement the logic "are we in the Packmaster's compendium tab" (which is more work than it might seem to figure out) just to fix just to fix a minor UI issue.

However, I already had to write that logic for that as part of cleaning up the compendium. With the function `isInPackmasterCardLibraryScreen` available to use, hiding the sort by packs button from other tabs only needed tweaks to a few existing patches and a few new patches that were relatively straightforward.

To summarize the changes:
* We use two new patches to prevent rendering or clicking the sort by packs button when you're on other tabs.
* When you switch to a non-Packmaster tab with sort by packs active, we ignore it, meaning that the tab acts exactly like it does when you first enter it with no sort selected.
* When you switch to a non-Packmaster tab with sort by packs active, then switch back to the Packmaster without changing sorting, we still sort by packs.
* The UI for other tabs will still look slightly different than normal, since the code that shrinks size of each sort button in order to fit in the new one is still active (even if the new button isn't there for other tabs). This is for the best, since it would be annoying and odd if the buttons resized themselves when you switched tabs.