### PR TITLE
Character event: switch the curse given by the Learn Dark Arts option to a new Packmaster-specific curse. Hi Vex!

### DIFF
--- a/src/main/java/thePackmaster/cards/Vexed.java
+++ b/src/main/java/thePackmaster/cards/Vexed.java
@@ -1,0 +1,37 @@
+package thePackmaster.cards;
+
+import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.SoulboundField;
+import com.megacrit.cardcrawl.actions.common.ExhaustSpecificCardAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thePackmaster.patches.odditiespack.PackmasterFoilPatches;
+
+import static thePackmaster.SpireAnniversary5Mod.makeID;
+
+public class Vexed extends AbstractPackmasterCard {
+    public final static String ID = makeID("Vexed");
+    private static final int COST = -2;
+
+    public Vexed() {
+        super(ID, COST, CardType.CURSE, CardRarity.SPECIAL, CardTarget.NONE, CardColor.CURSE);
+        SoulboundField.soulbound.set(this, true);
+    }
+
+    @Override
+    public void use(AbstractPlayer p, AbstractMonster m) {
+    }
+
+    @Override
+    public void upp() {
+    }
+
+    @Override
+    public void triggerOnOtherCardPlayed(AbstractCard c) {
+        if (PackmasterFoilPatches.isFoil(c)) {
+            this.superFlash();
+            this.addToTop(new ExhaustSpecificCardAction(this, AbstractDungeon.player.hand));
+        }
+    }
+}

--- a/src/main/java/thePackmaster/events/BlackMarketDealerEvent.java
+++ b/src/main/java/thePackmaster/events/BlackMarketDealerEvent.java
@@ -4,7 +4,6 @@ import basemod.abstracts.events.PhasedEvent;
 import basemod.abstracts.events.phases.TextPhase;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
-import com.megacrit.cardcrawl.cards.curses.CurseOfTheBell;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
@@ -18,6 +17,7 @@ import com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect;
 import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.cards.ConjurePack;
+import thePackmaster.cards.Vexed;
 import thePackmaster.hats.Hats;
 import thePackmaster.packs.AbstractCardPack;
 import thePackmaster.packs.CoreSetPack;
@@ -149,10 +149,9 @@ public class BlackMarketDealerEvent extends PhasedEvent {
                 }
 
                         .addOption(new TextPhase.OptionInfo(OPTIONS[11], new ConjurePack()), (i) -> {   //Curse & Pack Rip
-                            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new CurseOfTheBell(), (Settings.WIDTH * .33F), (float) (Settings.HEIGHT / 2)));
-                            //AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new CurseOfTheBell(), (Settings.WIDTH * .75F), (float) (Settings.HEIGHT / 2)));
+                            AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new Vexed(), (Settings.WIDTH * .33F), (float) (Settings.HEIGHT / 2)));
                             AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(new ConjurePack(), (Settings.WIDTH * .66F), (float) (Settings.HEIGHT / 2)));
-                            logMetricObtainCards(ID, "Conjure Pack", Arrays.asList(ConjurePack.ID, CurseOfTheBell.ID));
+                            logMetricObtainCards(ID, "Conjure Pack", Arrays.asList(ConjurePack.ID, Vexed.ID));
                             transitionKey("magicLearnEnd");
                         }).addOption(OPTIONS[12], (i) -> {   //Pack in a Jar Potion
                             AbstractDungeon.getCurrRoom().rewards.clear();

--- a/src/main/resources/anniv5Resources/localization/eng/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Cardstrings.json
@@ -19,5 +19,9 @@
     "NAME": "Conjure Pack",
     "DESCRIPTION": "Choose 1 of !M! Packs available to your run. NL At the start of the next 5 turns, add 2 of its cards to your hand.",
     "UPGRADE_DESCRIPTION": "Innate. NL Choose 1 of !M! Packs available to your run. NL At the start of the next 5 turns, add 2 of its cards to your hand."
+  },
+  "${ModID}:Vexed": {
+    "NAME": "Vexed",
+    "DESCRIPTION": "Unplayable. NL Cannot be removed from your deck. NL While in hand, Exhaust this when you play a *Foil card."
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/Eventstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/Eventstrings.json
@@ -29,7 +29,7 @@
       "[Trade-In] #gDo #gboth #g- #gSell #gonce, #gthen #gBuy #g2 #gof #g20 #gcards.",
       "[Locked] Requires ",
       "[Locked] No Cards to remove.",
-      "[Learn Dark Arts] #rBecome #rCursed #r- #rBell. #gObtain #gConjure #gPack.",
+      "[Learn Dark Arts] #rBecome #rCursed #r- #rVexed. #gObtain #gConjure #gPack.",
       "[Take Sample] #gObtain #gPack #gRip #gPotion.",
       "[Cleansing Ritual] #gRemove #ga #gcard #gfrom #gyour #gDeck.",
       "[Locked] No cards to remove.",


### PR DESCRIPTION
This PR doesn't have art yet, but I'm putting it up so that we have flexibility to do what we want with this change, regardless of whether I'm around and able to be actively doing stuff with it. From my perspective, the main options are:
* Merge this in and release even without art (the card art roller gives it fairly appropriate art, see below)
* Merge this in and add art (if Vex has it ready)
* Wait until after this release (if the art isn't ready, we don't want to release this change without art, and we don't want to delay the release for this)

I have very little preference between the options, beyond a general like for getting things merged in.

![image](https://user-images.githubusercontent.com/62083413/226182212-62d7fe63-40a6-4431-ba4b-705be5480283.png)
