### PR TITLE
Board Game pack: reduce Flick Dice damage by 2

### DIFF
--- a/src/main/java/thePackmaster/cards/boardgamepack/FlickDice.java
+++ b/src/main/java/thePackmaster/cards/boardgamepack/FlickDice.java
@@ -13,7 +13,7 @@ public class FlickDice extends AbstractBoardCard {
 
     public FlickDice() {
         super(ID, 1, CardType.ATTACK, CardRarity.COMMON, CardTarget.ENEMY);
-        damage = baseDamage = 10;
+        damage = baseDamage = 8;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {


### PR DESCRIPTION
This was discussed in Discord and Laugic (creator of the Board Game pack) agreed with the change.