### PR TITLE
Variety of small fixes

### DIFF
--- a/src/main/java/thePackmaster/cardmodifiers/gemspack/FrostGemMod.java
+++ b/src/main/java/thePackmaster/cardmodifiers/gemspack/FrostGemMod.java
@@ -28,6 +28,12 @@ public class FrostGemMod extends AbstractMadScienceModifier {
     }
 
     @Override
+    public void onInitialApplication(AbstractCard card) {
+        card.showEvokeValue = true;
+        card.showEvokeOrbCount += 1;
+    }
+
+    @Override
     public AbstractCardModifier makeCopy() {
         return new FrostGemMod();
     }

--- a/src/main/java/thePackmaster/cardmodifiers/gemspack/LightningGemMod.java
+++ b/src/main/java/thePackmaster/cardmodifiers/gemspack/LightningGemMod.java
@@ -29,6 +29,12 @@ public class LightningGemMod extends AbstractMadScienceModifier {
     }
 
     @Override
+    public void onInitialApplication(AbstractCard card) {
+        card.showEvokeValue = true;
+        card.showEvokeOrbCount += 1;
+    }
+
+    @Override
     public AbstractCardModifier makeCopy() {
         return new LightningGemMod();
     }

--- a/src/main/java/thePackmaster/cards/gemspack/FrostGem.java
+++ b/src/main/java/thePackmaster/cards/gemspack/FrostGem.java
@@ -15,6 +15,8 @@ public class FrostGem extends AbstractGemsCard {
 
     public FrostGem() {
         super(ID, 0, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.SELF);
+        this.showEvokeValue = true;
+        this.showEvokeOrbCount = 1;
     }
 
     @Override

--- a/src/main/java/thePackmaster/cards/gemspack/LightningGem.java
+++ b/src/main/java/thePackmaster/cards/gemspack/LightningGem.java
@@ -15,6 +15,8 @@ public class LightningGem extends AbstractGemsCard {
 
     public LightningGem() {
         super(ID, 0, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.SELF);
+        this.showEvokeValue = true;
+        this.showEvokeOrbCount = 1;
     }
 
     @Override

--- a/src/main/java/thePackmaster/cards/pixiepack/EnchantedRift.java
+++ b/src/main/java/thePackmaster/cards/pixiepack/EnchantedRift.java
@@ -8,6 +8,7 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.actions.pixiepack.DrawSpecificCardAction;
 import thePackmaster.packs.PixiePack;
 
@@ -35,7 +36,7 @@ public class EnchantedRift extends AbstractPixieCard {
     public void use(AbstractPlayer abstractPlayer, AbstractMonster abstractMonster) {
         addToBot(new GainBlockAction(abstractPlayer, block));
         AbstractCard lastDifferent = null;
-        for (int i = AbstractDungeon.actionManager.cardsPlayedThisCombat.size() - 2; i > 0; i--) {
+        for (int i = AbstractDungeon.actionManager.cardsPlayedThisCombat.size() - 2; i >= 0; i--) {
             if (PixiePack.isForeign(AbstractDungeon.actionManager.cardsPlayedThisCombat.get(i))) {
                 lastDifferent = AbstractDungeon.actionManager.cardsPlayedThisCombat.get(i);
                 break;

--- a/src/main/java/thePackmaster/relics/GemOfUnity.java
+++ b/src/main/java/thePackmaster/relics/GemOfUnity.java
@@ -26,12 +26,18 @@ public class GemOfUnity extends AbstractPackmasterRelic {
     public GemOfUnity() {
         super(ID, RelicTier.UNCOMMON, LandingSound.FLAT);
         resetCounter();
+    }
+
+    @Override
+    public void atBattleStartPreDraw() {
+        resetCounter();
         description = getUpdatedDescription();
     }
 
     @Override
     public void onVictory() {
         resetCounter();
+        description = DESCRIPTIONS[0];
     }
 
     public void resetCounter(){

--- a/src/main/resources/anniv5Resources/localization/eng/dragonwrathpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/dragonwrathpack/Cardstrings.json
@@ -1,7 +1,7 @@
 {
   "${ModID}:PenanceShock": {
     "NAME": "Penance Shock",
-    "DESCRIPTION": "Deal !D! damage and Apply !M! ${ModID}:Penance. NL Channel Lightning"
+    "DESCRIPTION": "Deal !D! damage and apply !M! ${ModID}:Penance. NL Channel 1 Lightning."
   },
   "${ModID}:Condemn": {
     "NAME": "Condemn",
@@ -9,7 +9,7 @@
   },
   "${ModID}:SearingLight": {
     "NAME": "Searing Light",
-    "DESCRIPTION": "Gain !B! Block. NL Channel ${ModID}:Light"
+    "DESCRIPTION": "Gain !B! Block. NL Channel 1 ${ModID}:Light."
   },
   "${ModID}:RazorWind": {
     "NAME": "Razor Wind",
@@ -25,7 +25,7 @@
   },
   "${ModID}:SacredTrial": {
     "NAME": "Sacred Trial",
-    "DESCRIPTION": "Take !M! damage. NL Channel !${ModID}:m2! Lightning"
+    "DESCRIPTION": "Take !M! damage. NL Channel !${ModID}:m2! Lightning."
   },
   "${ModID}:HolyWrath": {
     "NAME": "Holy Wrath",
@@ -33,10 +33,10 @@
   },
   "${ModID}:Absolution": {
     "NAME": "Absolution",
-    "DESCRIPTION": "Apply !M! ${ModID}:Penance. NL Whenever a creature is damaged by ${ModID}:Penance this turn apply !${ModID}:m2! Weak."
+    "DESCRIPTION": "Apply !M! ${ModID}:Penance. NL Whenever a creature is damaged by ${ModID}:Penance this turn, apply !${ModID}:m2! Weak."
   },
   "${ModID}:JudgementDay": {
     "NAME": "Judgement Day",
-    "DESCRIPTION": "${ModID}:Manifest !M! Lightning. NL Whenever a Lightning orbs passive effect activates gain !${ModID}:m2! ${ModID}:Confession."
+    "DESCRIPTION": "${ModID}:Manifest !M! Lightning. NL Whenever a Lightning orbs passive effect activates, gain !${ModID}:m2! ${ModID}:Confession."
   }
 }

--- a/src/main/resources/anniv5Resources/localization/eng/dragonwrathpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/dragonwrathpack/Keywordstrings.json
@@ -23,6 +23,6 @@
       "Light",
       "light"
     ],
-    "DESCRIPTION": "#yOrb - #yPassive : At the end of your turn gain #b1 #yConfession. NL #yEvoke : Gain #b3 #yConfession."
+    "DESCRIPTION": "#yOrb - #yPassive: At the end of your turn gain #b1 #yConfession. NL #yEvoke: Gain #b3 #yConfession."
   }
 ]

--- a/src/main/resources/anniv5Resources/localization/eng/metapack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/metapack/Cardstrings.json
@@ -36,8 +36,8 @@
   },
   "${ModID}:Bulwark": {
     "NAME": "Bulwark",
-    "DESCRIPTION": "Innate. NL Gain Temporary HP equal to your draw pile size. NL Exhaust.",
-    "EXTENDED_DESCRIPTION": [" NL (Gain !M! Temporary HP.)"]
+    "DESCRIPTION": "Innate. NL Gain Temporary_HP equal to your draw pile size. NL Exhaust.",
+    "EXTENDED_DESCRIPTION": [" NL (Gain !M! Temporary_HP.)"]
   },
   "${ModID}:Masterstroke": {
     "NAME": "Masterstroke",

--- a/src/main/resources/anniv5Resources/localization/eng/witchesstrikepack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/witchesstrikepack/Cardstrings.json
@@ -31,7 +31,7 @@
   },
   "${ModID}:WitchTwist": {
     "NAME": "Witch Twist",
-    "DESCRIPTION": "${ModID}:Modify !M! random cards in your hand : ${ModID}:Inscribed. NL Exhaust"
+    "DESCRIPTION": "${ModID}:Modify !M! random cards in your hand: ${ModID}:Inscribed. NL Exhaust."
   },
   "${ModID}:MoonlightFlight": {
     "NAME": "Moonlight Flight",


### PR DESCRIPTION
* Core relics: fix Gem of Unity displaying in combat description even when out of combat or on the run history screen
* Meta pack: fix Bulwark not using the keyword for temporary HP
* Pixie pack: fix Enchanted Rift not being able to make a copy of the first card played each combat
* Gems pack: add evoke orb indicators to gems and the cards they're applied to
* Dragonwrath pack: fix grammar issues
* Witches Strike pack: fix grammar issues