### PR TITLE
Sustenance Poison nerfed by 1

### DIFF
--- a/src/main/java/thePackmaster/cards/dimensiongatepack/Sustenance.java
+++ b/src/main/java/thePackmaster/cards/dimensiongatepack/Sustenance.java
@@ -15,7 +15,7 @@ public class Sustenance extends AbstractDimensionalCardVault {
     public Sustenance() {
         super(ID, 1, CardRarity.COMMON, CardType.SKILL, CardTarget.ALL_ENEMY);
         baseBlock = 5;
-        baseMagicNumber = magicNumber = 3;
+        baseMagicNumber = magicNumber = 2;
         PersistFields.setBaseValue(this, 2);
     }
 


### PR DESCRIPTION
Just proving a hair too reliable at common whenever I run into it.  5 block / 3 poison would probably be balanced if not for the Persist, the flexibility is worth more than I predicted.