### PR TITLE
Biting Cold pack: change Growing Affliction to reset its cost to 1 when it returns to your hand, to prevent infinites with Frostbite when Growing Affliction becomes 0 cost

### DIFF
--- a/src/main/java/thePackmaster/SpireAnniversary5Mod.java
+++ b/src/main/java/thePackmaster/SpireAnniversary5Mod.java
@@ -1174,8 +1174,19 @@ public class SpireAnniversary5Mod implements
             // Growing Affliction (Return to hand)
             if (source == adp() && !target.hasPower(ArtifactPower.POWER_ID))
                 for (AbstractCard c : AbstractDungeon.player.discardPile.group)
-                    if (c.cardID.equals(GrowingAffliction.ID))
+                    if (c.cardID.equals(GrowingAffliction.ID)) {
                         AbstractDungeon.actionManager.addToBottom(new DiscardToHandAction(c));
+                        AbstractDungeon.actionManager.addToBottom(new AbstractGameAction() {
+                            @Override
+                            public void update() {
+                                c.cost = 1;
+                                c.costForTurn = 1;
+                                c.isCostModified = false;
+                                this.isDone = true;
+                            }
+                        });
+
+                    }
 
             //Ring of Pain pack
             if (!target.hasPower(ArtifactPower.POWER_ID)) {

--- a/src/main/resources/anniv5Resources/localization/eng/bitingcoldpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/bitingcoldpack/Cardstrings.json
@@ -13,7 +13,7 @@
   },
   "${ModID}:GrowingAffliction": {
     "NAME": "Growing Affliction",
-    "DESCRIPTION": "Deal !D! damage. NL Whenever you apply a debuff, return this from the discard pile to your hand."
+    "DESCRIPTION": "Deal !D! damage. NL Whenever you apply a debuff, return this from the discard pile to your hand and set its cost to 1."
   },
   "${ModID}:InsultToInjury": {
     "NAME": "Insult to Injury",


### PR DESCRIPTION
There were a few posts about this in the balance feedback thread and I ran into it myself (I generated a 0-cost Growing Affliction with a Booster Brew), so I wanted to change it. Leaving this up for you to merge in case you'd prefer to do something different -- you're welcome to either engage on this with feedback (if you want) or just skim and merge.

See https://discord.com/channels/309399445785673728/398373038732738570/1098070305836118026 for some Discord discussion around this. Enbeon (the pack creator) was okay with the nerf: https://discord.com/channels/309399445785673728/398373038732738570/1098145691085307954.

I made this change because I didn't want to remove the interaction with Frostbite, since I felt the card is reasonably balanced under normal conditions. Similar to Shooting Echo or Shadow Strike, it becomes a way to turn as much energy as you want into damage. Given the comparison to those cards I also thought the design was fine and didn't want to rework the card entirely.

So I made a change that eliminates the infinite without making much difference to how the card normally works (it does make a slight difference when you have Snecko Eye or stuff like that). I consider it a bit inelegant, but still a positive change.