### PR TITLE
Custom draft: warn that the option for selecting None multiple times may cause crashes/freezes

### DIFF
--- a/src/main/resources/anniv5Resources/localization/eng/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/UIstrings.json
@@ -171,7 +171,7 @@
       "ALL PACKS MODE. Ignores Custom Draft, Doesn't Unlock Hats",
       "One Frame For All. All Pack cards have normal Packmaster frames (Requires Restart).",
       "Share Content. Some Relics/ Potions can appear on other characters (Requires Restart).",
-      "Allow selecting None multiple times in custom draft mode"
+      "Allow selecting None multiple times in custom draft mode (may cause crashes/freezes for some pack choices)"
     ]
   },
   "${ModID}:PMBoosterBoxCardReward": {

--- a/src/main/resources/anniv5Resources/localization/zhs/UIstrings.json
+++ b/src/main/resources/anniv5Resources/localization/zhs/UIstrings.json
@@ -171,7 +171,7 @@
       "全卡包模式：每局卡池都为所有卡包之和，该模式无法解锁帽子。",
       "卡框大师：所有卡包的卡框都使用卡包大师基础牌的牌框。(需要重启游戏)",
       "分享内容：一些卡包大师的遗物与药水可出现在其他角色的游戏中。(需要重启游戏)",
-      "Allow selecting none multiple times in custom draft mode"
+      "Allow selecting None multiple times in custom draft mode (may cause crashes/freezes for some pack choices)"
     ]
   },
   "${ModID}:PMBoosterBoxCardReward": {


### PR DESCRIPTION
We warned people about this in the Steam comment about the update. I'd like to have this warning in-game as well.

Leaving this for you to merge in case you want to discuss. My principle is that it's important to label things that may cause crashes and/or aren't fully supported, like this option. It helps set expectations.