### PR TITLE
Creativity pack: balance adjustments to bring cards and upgrades more in line with similar effects

### DIFF
--- a/src/main/java/thePackmaster/cards/creativitypack/BarrierBeacon.java
+++ b/src/main/java/thePackmaster/cards/creativitypack/BarrierBeacon.java
@@ -14,13 +14,13 @@ public class BarrierBeacon extends AbstractCreativityCard {
 
     public BarrierBeacon() {
         super(ID, 1, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
-        baseBlock = block = 9;
+        baseBlock = block = 7;
         exhaust = true;
     }
 
     @Override
     public void upp() {
-        upgradeBlock(3);
+        upgradeBlock(2);
     }
 
     @Override

--- a/src/main/java/thePackmaster/cards/creativitypack/MakeshiftShield.java
+++ b/src/main/java/thePackmaster/cards/creativitypack/MakeshiftShield.java
@@ -20,7 +20,7 @@ public class MakeshiftShield extends AbstractCreativityCard {
 
     @Override
     public void upp() {
-        upMagic(2);
+        upMagic(1);
     }
 
     @Override

--- a/src/main/java/thePackmaster/cards/creativitypack/StrikingStrike.java
+++ b/src/main/java/thePackmaster/cards/creativitypack/StrikingStrike.java
@@ -26,7 +26,6 @@ public class StrikingStrike extends AbstractCreativityCard {
 
     @Override
     public void upp() {
-        upgradeDamage(3);
     }
 
     @Override


### PR DESCRIPTION
* Reduce Makeshift Shield upgrade block by 1
* Remove Striking Strike upgrade damage increase
* Reduce Barrier Beacon block to 7 (9)

These cards all stood out as being above the power curve either overall or with their upgrade. Leaving this up for you to decide whether to merge or if more discussion is warranted.