### PR TITLE
Core set pack: balance tweaks for Flick and Backpack Smack

### DIFF
--- a/src/main/java/thePackmaster/cards/coresetpack/BackpackSmack.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/BackpackSmack.java
@@ -20,9 +20,7 @@ public class BackpackSmack extends AbstractPackmasterCard {
 
     public BackpackSmack() {
         super(ID, -1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
-        baseDamage = 6;
-        magicNumber = baseMagicNumber = 2;
-
+        baseDamage = 8;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/coresetpack/Flick.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/Flick.java
@@ -21,6 +21,7 @@ public class Flick extends AbstractPackmasterCard {
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
+        dmg(m, AbstractGameAction.AttackEffect.SLASH_HORIZONTAL);
         atb(new SelectCardsInHandAction(1, name + ".", (cards) -> {
             att(new DiscardSpecificCardAction(cards.get(0)));
             int cost = Wiz.getLogicalCardCost(cards.get(0));

--- a/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/coresetpack/Cardstrings.json
@@ -13,7 +13,7 @@
   },
   "${ModID}:Flick": {
     "NAME": "Flick",
-    "DESCRIPTION": "Discard a card. NL Deal !D! damage a number of times equal to its cost."
+    "DESCRIPTION": "Deal !D! damage. NL Discard a card. NL Deal !D! damage a number of times equal to its cost."
   },
   "${ModID}:MayhemForm": {
     "NAME": "Unrelenting Form",

--- a/src/main/resources/anniv5Resources/localization/zhs/coresetpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/zhs/coresetpack/Cardstrings.json
@@ -13,7 +13,7 @@
   },
   "${ModID}:Flick": {
     "NAME": "弹牌",
-    "DESCRIPTION": "丢弃一张牌。 NL 造成 !D! 点伤害其耗能次。"
+    "DESCRIPTION": "造成 !D! 点伤害。 NL 丢弃一张牌。 NL 造成 !D! 点伤害其耗能次。"
   },
   "${ModID}:MayhemForm": {
     "NAME": "不懈形态",


### PR DESCRIPTION
Leaving this up for you to decide whether to merge or if more discussion is warranted. I've written out my thoughts below.
* Core Set pack: increase Backpack Smack damage by 2
* Core Set pack: change Flick to deal damage an additional time (even if you don't discard a card)

Based on the card pick statistics and the discussion following them being posted, there are some cards in the core set that are rather weak. We don't need every card to be a star, but I think it's best for the core set to avoid having cards that are picked at really low rates and/or have consistent feedback about the card underperforming.

Both Flick and Backpack Smack fit that description. The comparison to similar base game cards also makes it clear they're below the normal power curve: Flick is often worse than Slice and Backpack Smack is often worse than Skewer, and Slice/Skewer are not particularly good themselves.

The current numbers should make them feel a bit better than Slice/Skewer in most situations (which seems fine since being better than mediocre base game cards is no big deal). We could consider damage being 1 lower for either card to make the power level a bit lower. I like the numbers in this PR since I don't think either of these are out of line with the rest of the core set (or most other packs). Plus clear buffs like this will help people give these cards a second look even if they're used to not taking them.

We could also consider reworks (a variety of interesting ideas were proposed). But I've kept these changes fairly simple, with the idea that this is a clear incremental improvement that any future changes can build on.