### PR TITLE
Pack selection: don't redo pack selection if the user saves and loads on floor 0 (or in any other case where we already have a pool)

### DIFF
--- a/src/main/java/thePackmaster/SpireAnniversary5Mod.java
+++ b/src/main/java/thePackmaster/SpireAnniversary5Mod.java
@@ -140,6 +140,7 @@ public class SpireAnniversary5Mod implements
         PostBattleSubscriber,
         PostPowerApplySubscriber,
         StartGameSubscriber,
+        PreStartGameSubscriber,
         PostExhaustSubscriber,
         OnPlayerTurnStartSubscriber,
         OnCreateDescriptionSubscriber,
@@ -1298,6 +1299,10 @@ public class SpireAnniversary5Mod implements
         }
     }
 
+    @Override
+    public void receivePreStartGame() {
+        SpireAnniversary5Mod.currentPoolPacks.clear();
+    }
 
     @Override
     public void receiveStartGame() {

--- a/src/main/java/thePackmaster/patches/OpeningRunScreenPatch.java
+++ b/src/main/java/thePackmaster/patches/OpeningRunScreenPatch.java
@@ -29,7 +29,7 @@ public class OpeningRunScreenPatch {
     )
     public static void SetTheThing(AbstractEvent __instance) {
         if(!Settings.isEndless || AbstractDungeon.floorNum <= 1) {
-            if (AbstractDungeon.player.chosenClass == ThePackmaster.Enums.THE_PACKMASTER) {
+            if (AbstractDungeon.player.chosenClass == ThePackmaster.Enums.THE_PACKMASTER && SpireAnniversary5Mod.currentPoolPacks.isEmpty()) {
                 if (SpireAnniversary5Mod.allPacksMode) {
                     SpireAnniversary5Mod.logger.info("Vex's All Packs Override Enabled. Skipping intro screen");
                     SpireAnniversary5Mod.currentPoolPacks.clear();


### PR DESCRIPTION
Previously, the only thing that ever cleared `SpireAnniversary5Mod.currentPoolPacks` was the pack selection code itself. That meant that we couldn't use it to check whether packs had already been selected for the run or not (since there might still be packs in the list from a previous Packmaster run, e.g. if you finish a Packmater run and then immediately start a new Packmaster run).

However, it's straightforward to clear the list of packs -- the `receivePreStartGame` hook is perfect for this. That hook executes when starting a new run or loading a run, and very importantly, it executes before the save file is loaded.

That means that with the new code in this PR, the sequence goes like this:
* `receivePreStartGame` executes and the list of packs is cleared
* (if loading a run) The save file is loaded, and the list of packs is overwritten with the packs from the save file due to the code in `initializeSavedData`
* (if starting a new run) The list of packs is left null
* `OpeningRunScreenPack executes (if you're in the Neow Event). If you're starting a new run, the list of packs will be empty, so the new check will be true and you'll get pack selection. If you're loading a run on floor 0, the list of packs won't be empty, so the new check will be false and you'll skip pack selection (because you already have packs).

Hopefully there are no strange cases this logic misses. I tested various ways of saving and reloading on floor 0, saving/reloading on floor 1+, and ending a PM run then starting a new run.

The new code in `receivePreStartGame` also means that `currentPoolPacks` will reliably be empty when playing a non-Packmaster character (since `receivePreStartGame` executes for all characters, but the code for adding packs only executes for Packmaster). Previously it might have had lingering packs from a previous Packmaster run, which could in theory have mattered if you got Prismatic Shard on another character and took certain Packmaster cards.