### PR TITLE
Various packs: fix Destiny Draw, Mimicry, More Explosions, Favor, and Retromation to work when played on other characters (e.g. if acquired through Prismatic Shard)

### DIFF
--- a/src/main/java/thePackmaster/cards/coresetpack/DestinyDraw.java
+++ b/src/main/java/thePackmaster/cards/coresetpack/DestinyDraw.java
@@ -4,6 +4,7 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePackmaster.SpireAnniversary5Mod;
+import thePackmaster.ThePackmaster;
 import thePackmaster.actions.FlexibleDiscoveryAction;
 import thePackmaster.cards.AbstractPackmasterCard;
 import thePackmaster.packs.AbstractCardPack;
@@ -22,7 +23,7 @@ public class DestinyDraw extends AbstractPackmasterCard {
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
-        ArrayList<AbstractCardPack> choices = SpireAnniversary5Mod.getRandomPacks(true, 3);
+        ArrayList<AbstractCardPack> choices = SpireAnniversary5Mod.getRandomPacks(p.chosenClass == ThePackmaster.Enums.THE_PACKMASTER, 3);
 
         ArrayList<AbstractCard> packCards = new ArrayList<>();
 

--- a/src/main/java/thePackmaster/cards/creativitypack/Mimicry.java
+++ b/src/main/java/thePackmaster/cards/creativitypack/Mimicry.java
@@ -7,8 +7,8 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.actions.FlexibleDiscoveryAction;
-import thePackmaster.packs.AbstractCardPack;
 import thePackmaster.packs.CreativityPack;
+import thePackmaster.util.Wiz;
 import thePackmaster.util.creativitypack.JediUtil;
 
 import java.util.ArrayList;
@@ -33,13 +33,7 @@ public class Mimicry extends AbstractCreativityCard {
         addToBot(new AbstractGameAction() {
             @Override
             public void update() {
-                ArrayList<AbstractCard> list = new ArrayList<>();
-                for (AbstractCardPack pack : SpireAnniversary5Mod.currentPoolPacks) {
-                    if (!CreativityPack.ID.equals(pack.packID)) {
-                        list.addAll(pack.cards);
-                    }
-                }
-                list.removeIf(c -> c.rarity != CardRarity.COMMON);
+                ArrayList<AbstractCard> list = Wiz.getCardsMatchingPredicate(c -> c.rarity == CardRarity.COMMON && !CreativityPack.ID.equals(SpireAnniversary5Mod.cardParentMap.getOrDefault(c.cardID, null)) && !c.hasTag(CardTags.HEALING));
                 if (list.isEmpty()) {
                     isDone = true;
                     return;

--- a/src/main/java/thePackmaster/cards/goddessofexplosionspack/MoreExplosions.java
+++ b/src/main/java/thePackmaster/cards/goddessofexplosionspack/MoreExplosions.java
@@ -9,19 +9,15 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePackmaster.SpireAnniversary5Mod;
-import thePackmaster.packs.AbstractCardPack;
 import thePackmaster.util.Wiz;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import static thePackmaster.SpireAnniversary5Mod.currentPoolPacks;
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public class MoreExplosions extends AbstractGoddessOfExplosionsCard {
     public final static String ID = makeID("MoreExplosions");
-    private static final UIStrings uiStrings = CardCrawlGame.languagePack.getUIString(SpireAnniversary5Mod.makeID("PlayTwiceUI"));
 
     private static final int MAGIC = 1;
     private static final int MAGIC_UP = 1;
@@ -33,23 +29,9 @@ public class MoreExplosions extends AbstractGoddessOfExplosionsCard {
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        // I'll be moderately mad if there's an automated way of doing this.
         // List of powers.
-        List<AbstractCard> eligibleCards = new ArrayList<>();
+        List<AbstractCard> eligibleCards = Wiz.getCardsMatchingPredicate(c -> c.type == CardType.POWER && !c.hasTag(AbstractCard.CardTags.HEALING));
         List<AbstractCard> powerList = new ArrayList<>();
-
-        // Compile ALL eligible cards.
-        for(AbstractCardPack pack : currentPoolPacks)
-        {
-            List<AbstractCard> validCards = pack.cards
-                    .stream()
-                    .filter(c -> c.type == CardType.POWER)
-                    .filter(c -> !c.hasTag(AbstractCard.CardTags.HEALING))
-                    .filter(c -> c.rarity == CardRarity.COMMON || c.rarity == CardRarity.UNCOMMON || c.rarity == CardRarity.RARE)
-                    .collect(Collectors.toList());
-
-            eligibleCards.addAll(validCards);
-        }
 
         // Add from eligible cards to power list.
         for(int hm = 0; hm < magicNumber; hm++) {

--- a/src/main/java/thePackmaster/cards/intriguepack/Favor.java
+++ b/src/main/java/thePackmaster/cards/intriguepack/Favor.java
@@ -9,14 +9,10 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePackmaster.cardmodifiers.energyandechopack.EchoedEtherealMod;
 import thePackmaster.cardmodifiers.energyandechopack.GlowEchoMod;
-import thePackmaster.packs.AbstractCardPack;
 import thePackmaster.util.Wiz;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import static thePackmaster.SpireAnniversary5Mod.currentPoolPacks;
 import static thePackmaster.SpireAnniversary5Mod.makeID;
 
 public class Favor extends AbstractIntrigueCard {
@@ -29,19 +25,7 @@ public class Favor extends AbstractIntrigueCard {
 
     public void use(AbstractPlayer p, AbstractMonster m) {
         // List of rares.
-        List<AbstractCard> eligibleCards = new ArrayList<>();
-
-        // Compile ALL eligible cards.
-        for(AbstractCardPack pack : currentPoolPacks)
-        {
-            List<AbstractCard> validCards = pack.cards
-                    .stream()
-                    .filter(c -> c.rarity == CardRarity.RARE)
-                    .filter(c -> !c.hasTag(AbstractCard.CardTags.HEALING))
-                    .collect(Collectors.toList());
-
-            eligibleCards.addAll(validCards);
-        }
+        List<AbstractCard> eligibleCards = Wiz.getCardsMatchingPredicate(c -> c.rarity == CardRarity.RARE && !c.hasTag(AbstractCard.CardTags.HEALING));
 
         // Add one of them to hand.
         if (eligibleCards.size() > 0) {


### PR DESCRIPTION
After making the `receivePreStartGame` change from the previous PR, I looked through the Packmaster codebase for uses of `currentPoolPacks`. I found a few that I could tell would break if you played them on another character, where `currentPoolPacks` would be empty.

Very niche but figured I'd fix them... especially since a bunch of them could use the `Wiz.getCardsMatchingPredicate` function that does almost everything for you. That means this also simplified the code a lot. While I was at it I also fixed Destiny Draw -- the code changes weren't related, but it was another card I knew didn't work properly on other characters.

Leaving this one up for you to take a look over in case you're curious. At the very least, you might appreciate the code simplification.