### PR TITLE
Add easier method for creating pack summary

### DIFF
--- a/src/main/java/thePackmaster/SpireAnniversary5Mod.java
+++ b/src/main/java/thePackmaster/SpireAnniversary5Mod.java
@@ -8,7 +8,6 @@ import basemod.abstracts.CustomSavable;
 import basemod.devcommands.ConsoleCommand;
 import basemod.eventUtil.AddEventParams;
 import basemod.eventUtil.EventUtils;
-import basemod.helpers.BaseModCardTags;
 import basemod.helpers.CardBorderGlowManager;
 import basemod.helpers.RelicType;
 import basemod.helpers.TextCodeInterpreter;
@@ -105,7 +104,6 @@ import thePackmaster.summaries.PackSummaryDisplay;
 import thePackmaster.summaries.PackSummaryReader;
 import thePackmaster.ui.*;
 import thePackmaster.ui.FixedModLabeledToggleButton.FixedModLabeledToggleButton;
-import thePackmaster.util.Wiz;
 import thePackmaster.util.Keywords;
 import thePackmaster.util.TexLoader;
 import thePackmaster.util.cardvars.HoardVar;
@@ -1055,8 +1053,7 @@ public class SpireAnniversary5Mod implements
             PackSummary summary = PackSummaryReader.getPackSummary(p.packID);
             if (summary != null) {
                 PackSummaryDisplay.getTooltip(summary);
-            }
-            else {
+            } else {
                 SpireAnniversary5Mod.logger.error("Please fill out the ratings and tags before releasing pack " + p.packID);
             }
         }

--- a/src/main/java/thePackmaster/packs/AbstractCardPack.java
+++ b/src/main/java/thePackmaster/packs/AbstractCardPack.java
@@ -6,6 +6,7 @@ import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.hats.HatMenu;
+import thePackmaster.summaries.PackSummary;
 
 import java.util.ArrayList;
 
@@ -76,4 +77,8 @@ public abstract class AbstractCardPack {
         return hatStrings.TEXT[0];
     }
 
+    //Allows for generating your own PackSummary instead of modifying the text file
+    public PackSummary getPackSummary() {
+        return null;
+    }
 }

--- a/src/main/java/thePackmaster/packs/MarisaPack.java
+++ b/src/main/java/thePackmaster/packs/MarisaPack.java
@@ -4,6 +4,7 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.cards.marisapack.*;
+import thePackmaster.summaries.PackSummary;
 
 import java.util.ArrayList;
 
@@ -34,5 +35,13 @@ public class MarisaPack extends AbstractCardPack {
         cards.add(DragonMeteor.ID);
         cards.add(EarthlightRay.ID);
         return cards;
+    }
+
+    @Override
+    public PackSummary getPackSummary() {
+        PackSummary pSum = new PackSummary(4, 1, 3, 4,3);
+        pSum.setTags("Exhaust", "Attacks");
+
+        return pSum;
     }
 }

--- a/src/main/java/thePackmaster/summaries/PackSummary.java
+++ b/src/main/java/thePackmaster/summaries/PackSummary.java
@@ -1,8 +1,27 @@
 package thePackmaster.summaries;
 
+import java.util.Arrays;
 import java.util.HashSet;
 
 public class PackSummary {
+    public PackSummary() {
+    }
+
+    public PackSummary(int offense, int defense, int support, int frontload, int scaling) {
+        this.offense = offense;
+        this.defense = defense;
+        this.support = support;
+        this.frontload = frontload;
+        this.scaling = scaling;
+        tags = new HashSet<>();
+        tags.add(PackSummaryReader.NONE_TAG);
+    }
+
+    public void setTags(String... tags) {
+        this.tags.clear();
+        this.tags.addAll(Arrays.asList(tags));
+    }
+
     public int offense;
     public int defense;
     public int support;

--- a/src/main/java/thePackmaster/summaries/PackSummaryReader.java
+++ b/src/main/java/thePackmaster/summaries/PackSummaryReader.java
@@ -109,6 +109,15 @@ public class PackSummaryReader {
             e.printStackTrace();
         }
 
+        SpireAnniversary5Mod.unfilteredAllPacks.stream()
+                .filter(p -> !packSummaries.containsKey(p.packID))
+                .forEach(p -> {
+                    PackSummary pSum = p.getPackSummary();
+                    if (pSum != null) {
+                        packSummaries.put(p.packID, pSum);
+                    }
+                });
+
         packDiagnostics(packSummaries);
 
         return packSummaries;

--- a/src/main/resources/anniv5Resources/summaries/ratings.txt
+++ b/src/main/resources/anniv5Resources/summaries/ratings.txt
@@ -51,7 +51,6 @@ JockeyPack	3	2	4	2	4
 LegacyPack	3	2	2	3	2
 LockonPack	3	2	3	2	4
 MadSciencePack	3	3	5	2	3
-MarisaPack	4	1	3	4	3
 MetaPack	3	2	2	3	3
 MonsterHunterPack	4	2	2	3	3
 OdditiesPack	2	1	5	2	3

--- a/src/main/resources/anniv5Resources/summaries/tags.txt
+++ b/src/main/resources/anniv5Resources/summaries/tags.txt
@@ -51,7 +51,6 @@ LegacyPack	Exhaust
 LockonPack	Orbs
 JockeyPack	None
 MadSciencePack	Orbs
-MarisaPack	Exhaust,Attacks
 MetaPack	None
 MonsterHunterPack	None
 OdditiesPack	None


### PR DESCRIPTION
Pack Summary is a nice feature, but it was pointed out it's a bit hard to use from the outside.

Since we'll likely have an expansion packs mod soon, I've added an easier way of adding your own pack summary while keeping the old style for compatibility sake. Although, I do think it's a bit cumbersome and might be worth removing the text file at some point. It's noticeable in the amount of packs that were PR'ed without a summary or tags. The error logging is a nice touch, but it's easy to miss since there are so many logging calls that early into the intialization.