### PR TITLE
Change PackSummary to use enums instead of strings

### DIFF
--- a/src/main/java/thePackmaster/packs/AbstractCardPack.java
+++ b/src/main/java/thePackmaster/packs/AbstractCardPack.java
@@ -84,13 +84,14 @@ public abstract class AbstractCardPack {
     }
 
     public static class PackSummary {
-        public static final String NONE_TAG = "None";
-
+        public enum Tags {
+            None, Strength, Exhaust, Orbs, Stances, Discard, Debuffs, Attacks, Tokens, Powers
+        }
 
         public int offense, defense, support, frontload, scaling;
-        public HashSet<String> tags = new HashSet<>();
+        public HashSet<Tags> tags = new HashSet<>();
 
-        public PackSummary(int offense, int defense, int support, int frontload, int scaling, String... tags) {
+        public PackSummary(int offense, int defense, int support, int frontload, int scaling, Tags... tags) {
             this.offense = offense;
             this.defense = defense;
             this.support = support;
@@ -98,7 +99,7 @@ public abstract class AbstractCardPack {
             this.scaling = scaling;
             Collections.addAll(this.tags, tags);
             if (this.tags.isEmpty())
-                this.tags.add(NONE_TAG);
+                this.tags.add(Tags.None);
         }
     }
 }

--- a/src/main/java/thePackmaster/packs/AggressionPack.java
+++ b/src/main/java/thePackmaster/packs/AggressionPack.java
@@ -16,7 +16,7 @@ public class AggressionPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public AggressionPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(5, 2, 2, 4, 3, "Strength", "Stances", "Attacks"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(5, 2, 2, 4, 3, PackSummary.Tags.Strength, PackSummary.Tags.Stances, PackSummary.Tags.Attacks));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/AggressionPack.java
+++ b/src/main/java/thePackmaster/packs/AggressionPack.java
@@ -16,7 +16,7 @@ public class AggressionPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public AggressionPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(5, 2, 2, 4, 3, PackSummary.Tags.Strength, PackSummary.Tags.Stances, PackSummary.Tags.Attacks));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(5, 2, 2, 4, 3, PackSummary.Tags.Strength, PackSummary.Tags.Stances, PackSummary.Tags.Attacks));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/AlignmentPack.java
+++ b/src/main/java/thePackmaster/packs/AlignmentPack.java
@@ -18,7 +18,7 @@ public class AlignmentPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public AlignmentPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 5, 2, 2, PackSummary.Tags.Exhaust, PackSummary.Tags.Discard));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 3, 5, 2, 2, PackSummary.Tags.Exhaust, PackSummary.Tags.Discard));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/AlignmentPack.java
+++ b/src/main/java/thePackmaster/packs/AlignmentPack.java
@@ -18,7 +18,7 @@ public class AlignmentPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public AlignmentPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 5, 2, 2, "Exhaust", "Discard"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 5, 2, 2, PackSummary.Tags.Exhaust, PackSummary.Tags.Discard));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/AllForOnePack.java
+++ b/src/main/java/thePackmaster/packs/AllForOnePack.java
@@ -18,7 +18,7 @@ public class AllForOnePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public AllForOnePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 3, 4, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 2, 3, 4, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/AnomalyPack.java
+++ b/src/main/java/thePackmaster/packs/AnomalyPack.java
@@ -15,7 +15,7 @@ public class AnomalyPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public AnomalyPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 4, 1, 4, PackSummary.Tags.Exhaust, PackSummary.Tags.Discard));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 3, 4, 1, 4, PackSummary.Tags.Exhaust, PackSummary.Tags.Discard));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/AnomalyPack.java
+++ b/src/main/java/thePackmaster/packs/AnomalyPack.java
@@ -15,7 +15,7 @@ public class AnomalyPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public AnomalyPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 4, 1, 4, "Exhaust", "Discard"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 4, 1, 4, PackSummary.Tags.Exhaust, PackSummary.Tags.Discard));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/ArcanaPack.java
+++ b/src/main/java/thePackmaster/packs/ArcanaPack.java
@@ -18,7 +18,7 @@ public class ArcanaPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ArcanaPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 3, 3, 2));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 3, 3, 2));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ArtificerPack.java
+++ b/src/main/java/thePackmaster/packs/ArtificerPack.java
@@ -16,7 +16,7 @@ public class ArtificerPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ArtificerPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 4, 4, 3, PackSummary.Tags.Discard));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 2, 4, 4, 3, PackSummary.Tags.Discard));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ArtificerPack.java
+++ b/src/main/java/thePackmaster/packs/ArtificerPack.java
@@ -16,7 +16,7 @@ public class ArtificerPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ArtificerPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 4, 4, 3, "Discard"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 4, 4, 3, PackSummary.Tags.Discard));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/BardInspirePack.java
+++ b/src/main/java/thePackmaster/packs/BardInspirePack.java
@@ -15,7 +15,7 @@ public class BardInspirePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public BardInspirePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 2, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 4, 2, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/BasicsPack.java
+++ b/src/main/java/thePackmaster/packs/BasicsPack.java
@@ -15,7 +15,7 @@ public class BasicsPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public BasicsPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 2, 4, 2));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 2, 4, 2));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/BatterPack.java
+++ b/src/main/java/thePackmaster/packs/BatterPack.java
@@ -16,7 +16,7 @@ public class BatterPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public BatterPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 2, 2, 4, 2, "Attacks"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 2, 2, 4, 2, PackSummary.Tags.Attacks));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/BatterPack.java
+++ b/src/main/java/thePackmaster/packs/BatterPack.java
@@ -16,7 +16,7 @@ public class BatterPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public BatterPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 2, 2, 4, 2, PackSummary.Tags.Attacks));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(4, 2, 2, 4, 2, PackSummary.Tags.Attacks));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/BellordPack.java
+++ b/src/main/java/thePackmaster/packs/BellordPack.java
@@ -15,7 +15,7 @@ public class BellordPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public BellordPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 2, 4, 1));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 3, 2, 4, 1));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/BitingColdPack.java
+++ b/src/main/java/thePackmaster/packs/BitingColdPack.java
@@ -15,7 +15,7 @@ public class BitingColdPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public BitingColdPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 2, 3, 3, "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 2, 3, 3, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/BitingColdPack.java
+++ b/src/main/java/thePackmaster/packs/BitingColdPack.java
@@ -15,7 +15,7 @@ public class BitingColdPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public BitingColdPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 2, 3, 3, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 2, 2, 3, 3, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/BlacksmithsPack.java
+++ b/src/main/java/thePackmaster/packs/BlacksmithsPack.java
@@ -16,7 +16,7 @@ public class BlacksmithsPack extends AbstractCardPack{
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public BlacksmithsPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 4, 4));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 4, 4, 4));
     }
     @Override
     public ArrayList<String> getCards() {

--- a/src/main/java/thePackmaster/packs/BoardGamePack.java
+++ b/src/main/java/thePackmaster/packs/BoardGamePack.java
@@ -17,7 +17,7 @@ public class BoardGamePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public BoardGamePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 2, 4, 2));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 2, 4, 2));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/BulwarkPack.java
+++ b/src/main/java/thePackmaster/packs/BulwarkPack.java
@@ -24,7 +24,7 @@ public class BulwarkPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public BulwarkPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 5, 1, 4, 4, "Exhaust"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 5, 1, 4, 4, PackSummary.Tags.Exhaust));
         this.hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/BulwarkPack.java
+++ b/src/main/java/thePackmaster/packs/BulwarkPack.java
@@ -24,7 +24,7 @@ public class BulwarkPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public BulwarkPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 5, 1, 4, 4, PackSummary.Tags.Exhaust));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 5, 1, 4, 4, PackSummary.Tags.Exhaust));
         this.hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/CalamityPack.java
+++ b/src/main/java/thePackmaster/packs/CalamityPack.java
@@ -16,7 +16,7 @@ public class CalamityPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public CalamityPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 2, 2, 3, 4, "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 2, 2, 3, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/CalamityPack.java
+++ b/src/main/java/thePackmaster/packs/CalamityPack.java
@@ -16,7 +16,7 @@ public class CalamityPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public CalamityPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 2, 2, 3, 4, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(4, 2, 2, 3, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ClawPack.java
+++ b/src/main/java/thePackmaster/packs/ClawPack.java
@@ -1,11 +1,9 @@
 package thePackmaster.packs;
 
-import com.megacrit.cardcrawl.cards.blue.Claw;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.cards.clawpack.*;
-import thePackmaster.cards.downfallpack.*;
 
 import java.util.ArrayList;
 
@@ -17,7 +15,7 @@ public class ClawPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ClawPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(5, 2, 1, 2, 5, "Tokens"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(5, 2, 1, 2, 5, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ClawPack.java
+++ b/src/main/java/thePackmaster/packs/ClawPack.java
@@ -15,7 +15,7 @@ public class ClawPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ClawPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(5, 2, 1, 2, 5, PackSummary.Tags.Tokens));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(5, 2, 1, 2, 5, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ColorlessPack.java
+++ b/src/main/java/thePackmaster/packs/ColorlessPack.java
@@ -15,7 +15,7 @@ public class ColorlessPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ColorlessPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, "Tokens"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ColorlessPack.java
+++ b/src/main/java/thePackmaster/packs/ColorlessPack.java
@@ -15,7 +15,7 @@ public class ColorlessPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ColorlessPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Tokens));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ConjurerPack.java
+++ b/src/main/java/thePackmaster/packs/ConjurerPack.java
@@ -17,7 +17,7 @@ public class ConjurerPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ConjurerPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 4, 2, 2, 3, "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 4, 2, 2, 3, PackSummary.Tags.Debuffs));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/ConjurerPack.java
+++ b/src/main/java/thePackmaster/packs/ConjurerPack.java
@@ -17,7 +17,7 @@ public class ConjurerPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ConjurerPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 4, 2, 2, 3, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 4, 2, 2, 3, PackSummary.Tags.Debuffs));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/ContentCreatorPack.java
+++ b/src/main/java/thePackmaster/packs/ContentCreatorPack.java
@@ -16,7 +16,7 @@ public class ContentCreatorPack extends AbstractCardPack{
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public ContentCreatorPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(2, 2, 4, 2, 4, "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(2, 2, 4, 2, 4, PackSummary.Tags.Orbs));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/ContentCreatorPack.java
+++ b/src/main/java/thePackmaster/packs/ContentCreatorPack.java
@@ -16,7 +16,7 @@ public class ContentCreatorPack extends AbstractCardPack{
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public ContentCreatorPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(2, 2, 4, 2, 4, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(2, 2, 4, 2, 4, PackSummary.Tags.Orbs));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/CoreSetPack.java
+++ b/src/main/java/thePackmaster/packs/CoreSetPack.java
@@ -15,7 +15,7 @@ public class CoreSetPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public CoreSetPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 3, 3, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 3, 3, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/CosmosCommandPack.java
+++ b/src/main/java/thePackmaster/packs/CosmosCommandPack.java
@@ -15,7 +15,7 @@ public class CosmosCommandPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public CosmosCommandPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 4, 1, 4, "Exhaust", "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 4, 1, 4, PackSummary.Tags.Exhaust, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/CosmosCommandPack.java
+++ b/src/main/java/thePackmaster/packs/CosmosCommandPack.java
@@ -15,7 +15,7 @@ public class CosmosCommandPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public CosmosCommandPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 4, 1, 4, PackSummary.Tags.Exhaust, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 2, 4, 1, 4, PackSummary.Tags.Exhaust, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/CreativityPack.java
+++ b/src/main/java/thePackmaster/packs/CreativityPack.java
@@ -16,7 +16,7 @@ public class CreativityPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public CreativityPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 3, 1, "Tokens"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 3, 1, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/CreativityPack.java
+++ b/src/main/java/thePackmaster/packs/CreativityPack.java
@@ -16,7 +16,7 @@ public class CreativityPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public CreativityPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 3, 1, PackSummary.Tags.Tokens));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 4, 3, 1, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/CthulhuPack.java
+++ b/src/main/java/thePackmaster/packs/CthulhuPack.java
@@ -17,7 +17,7 @@ public class CthulhuPack extends AbstractCardPack {
     public static int lunacyThisCombat;
 
     public CthulhuPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 4, 3, 1, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 4, 3, 1, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DarkSoulsPack.java
+++ b/src/main/java/thePackmaster/packs/DarkSoulsPack.java
@@ -15,7 +15,7 @@ public class DarkSoulsPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public DarkSoulsPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 2, 4, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 2, 4, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DefectPack.java
+++ b/src/main/java/thePackmaster/packs/DefectPack.java
@@ -15,7 +15,7 @@ public class DefectPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public DefectPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 4, 3, 4, 3, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 4, 3, 4, 3, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DefectPack.java
+++ b/src/main/java/thePackmaster/packs/DefectPack.java
@@ -15,7 +15,7 @@ public class DefectPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public DefectPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 4, 3, 4, 3, "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 4, 3, 4, 3, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DimensionGatePack.java
+++ b/src/main/java/thePackmaster/packs/DimensionGatePack.java
@@ -17,7 +17,7 @@ public class DimensionGatePack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public DimensionGatePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DimensionGatePack.java
+++ b/src/main/java/thePackmaster/packs/DimensionGatePack.java
@@ -17,7 +17,7 @@ public class DimensionGatePack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public DimensionGatePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DimensionGatePack2.java
+++ b/src/main/java/thePackmaster/packs/DimensionGatePack2.java
@@ -17,7 +17,7 @@ public class DimensionGatePack2 extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public DimensionGatePack2() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DimensionGatePack2.java
+++ b/src/main/java/thePackmaster/packs/DimensionGatePack2.java
@@ -17,7 +17,7 @@ public class DimensionGatePack2 extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public DimensionGatePack2() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DimensionGatePack3.java
+++ b/src/main/java/thePackmaster/packs/DimensionGatePack3.java
@@ -16,7 +16,7 @@ public class DimensionGatePack3 extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public DimensionGatePack3() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DimensionGatePack3.java
+++ b/src/main/java/thePackmaster/packs/DimensionGatePack3.java
@@ -16,7 +16,7 @@ public class DimensionGatePack3 extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public DimensionGatePack3() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DistortionPack.java
+++ b/src/main/java/thePackmaster/packs/DistortionPack.java
@@ -27,7 +27,7 @@ public class DistortionPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public DistortionPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 3, 4, 4, PackSummary.Tags.Exhaust));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 2, 3, 4, 4, PackSummary.Tags.Exhaust));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DistortionPack.java
+++ b/src/main/java/thePackmaster/packs/DistortionPack.java
@@ -27,7 +27,7 @@ public class DistortionPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public DistortionPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 3, 4, 4, "Exhaust"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 3, 4, 4, PackSummary.Tags.Exhaust));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DownfallPack.java
+++ b/src/main/java/thePackmaster/packs/DownfallPack.java
@@ -15,7 +15,7 @@ public class DownfallPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public DownfallPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 3, 3, 3, "Stances", "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 3, 3, 3, PackSummary.Tags.Stances, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DownfallPack.java
+++ b/src/main/java/thePackmaster/packs/DownfallPack.java
@@ -15,7 +15,7 @@ public class DownfallPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public DownfallPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 3, 3, 3, PackSummary.Tags.Stances, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 3, 3, 3, 3, PackSummary.Tags.Stances, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DragonwrathPack.java
+++ b/src/main/java/thePackmaster/packs/DragonwrathPack.java
@@ -16,7 +16,7 @@ public class DragonwrathPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public DragonwrathPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 1, 2, 5, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 2, 1, 2, 5, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/DragonwrathPack.java
+++ b/src/main/java/thePackmaster/packs/DragonwrathPack.java
@@ -16,7 +16,7 @@ public class DragonwrathPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public DragonwrathPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 1, 2, 5, "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 1, 2, 5, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/EnergyAndEchoPack.java
+++ b/src/main/java/thePackmaster/packs/EnergyAndEchoPack.java
@@ -24,7 +24,7 @@ public class EnergyAndEchoPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public EnergyAndEchoPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 4, 4, 2, PackSummary.Tags.Exhaust, PackSummary.Tags.Tokens));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 2, 4, 4, 2, PackSummary.Tags.Exhaust, PackSummary.Tags.Tokens));
     }
     public static int generatedEnergy = 0;
     public static int usedEnergy = 0;

--- a/src/main/java/thePackmaster/packs/EnergyAndEchoPack.java
+++ b/src/main/java/thePackmaster/packs/EnergyAndEchoPack.java
@@ -24,7 +24,7 @@ public class EnergyAndEchoPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public EnergyAndEchoPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 4, 4, 2, "Exhaust", "Tokens"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 4, 4, 2, PackSummary.Tags.Exhaust, PackSummary.Tags.Tokens));
     }
     public static int generatedEnergy = 0;
     public static int usedEnergy = 0;

--- a/src/main/java/thePackmaster/packs/EntropyPack.java
+++ b/src/main/java/thePackmaster/packs/EntropyPack.java
@@ -15,7 +15,7 @@ public class EntropyPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public EntropyPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 2, 3, 3, PackSummary.Tags.Discard, PackSummary.Tags.Debuffs, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 2, 2, 3, 3, PackSummary.Tags.Discard, PackSummary.Tags.Debuffs, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/EntropyPack.java
+++ b/src/main/java/thePackmaster/packs/EntropyPack.java
@@ -15,7 +15,7 @@ public class EntropyPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public EntropyPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 2, 3, 3, "Discard", "Debuffs", "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 2, 3, 3, PackSummary.Tags.Discard, PackSummary.Tags.Debuffs, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/EvenOddPack.java
+++ b/src/main/java/thePackmaster/packs/EvenOddPack.java
@@ -16,7 +16,7 @@ public class EvenOddPack extends AbstractCardPack {
     public static final String GRAY = "[#808080]";
     
     public EvenOddPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 4, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 4, 4, 3));
     }
     
     @Override

--- a/src/main/java/thePackmaster/packs/FarmerPack.java
+++ b/src/main/java/thePackmaster/packs/FarmerPack.java
@@ -16,7 +16,7 @@ public class FarmerPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public FarmerPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 3, 2, 1));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 2, 3, 2, 1));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/FrostPack.java
+++ b/src/main/java/thePackmaster/packs/FrostPack.java
@@ -17,7 +17,7 @@ public class FrostPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public FrostPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 5, 3, 1, 4, "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 5, 3, 1, 4, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/FrostPack.java
+++ b/src/main/java/thePackmaster/packs/FrostPack.java
@@ -17,7 +17,7 @@ public class FrostPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public FrostPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 5, 3, 1, 4, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 5, 3, 1, 4, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/GemsPack.java
+++ b/src/main/java/thePackmaster/packs/GemsPack.java
@@ -25,7 +25,7 @@ public class GemsPack extends AbstractCardPack {
 
 
     public GemsPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(1, 1, 5, 1, 4, "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(1, 1, 5, 1, 4, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/GemsPack.java
+++ b/src/main/java/thePackmaster/packs/GemsPack.java
@@ -25,7 +25,7 @@ public class GemsPack extends AbstractCardPack {
 
 
     public GemsPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(1, 1, 5, 1, 4, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(1, 1, 5, 1, 4, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/GoWithTheFlowPack.java
+++ b/src/main/java/thePackmaster/packs/GoWithTheFlowPack.java
@@ -15,7 +15,7 @@ public class GoWithTheFlowPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public GoWithTheFlowPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 3, 2, "Discard"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 3, 2, PackSummary.Tags.Discard));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/GoWithTheFlowPack.java
+++ b/src/main/java/thePackmaster/packs/GoWithTheFlowPack.java
@@ -15,7 +15,7 @@ public class GoWithTheFlowPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public GoWithTheFlowPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 3, 2, PackSummary.Tags.Discard));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 4, 3, 2, PackSummary.Tags.Discard));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/GoddessOfExplosionsPack.java
+++ b/src/main/java/thePackmaster/packs/GoddessOfExplosionsPack.java
@@ -16,7 +16,7 @@ public class GoddessOfExplosionsPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public GoddessOfExplosionsPack() {
-        super(ID, NAME, DESC, AUTHOR,CREDITS, new AbstractCardPack.PackSummary(4, 2, 3, 1, 5, "Powers"));
+        super(ID, NAME, DESC, AUTHOR,CREDITS, new AbstractCardPack.PackSummary(4, 2, 3, 1, 5, PackSummary.Tags.Powers));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/GoddessOfExplosionsPack.java
+++ b/src/main/java/thePackmaster/packs/GoddessOfExplosionsPack.java
@@ -16,7 +16,7 @@ public class GoddessOfExplosionsPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public GoddessOfExplosionsPack() {
-        super(ID, NAME, DESC, AUTHOR,CREDITS, new AbstractCardPack.PackSummary(4, 2, 3, 1, 5, PackSummary.Tags.Powers));
+        super(ID, NAME, DESC, AUTHOR,CREDITS, new PackSummary(4, 2, 3, 1, 5, PackSummary.Tags.Powers));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/GrandOpeningPack.java
+++ b/src/main/java/thePackmaster/packs/GrandOpeningPack.java
@@ -15,7 +15,7 @@ public class GrandOpeningPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public GrandOpeningPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 3, 3, 2));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 2, 3, 3, 2));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/GraveyardPack.java
+++ b/src/main/java/thePackmaster/packs/GraveyardPack.java
@@ -15,7 +15,7 @@ public class GraveyardPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public GraveyardPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 1, 4, 3, 4, PackSummary.Tags.Exhaust));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 1, 4, 3, 4, PackSummary.Tags.Exhaust));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/GraveyardPack.java
+++ b/src/main/java/thePackmaster/packs/GraveyardPack.java
@@ -15,7 +15,7 @@ public class GraveyardPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public GraveyardPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 1, 4, 3, 4, "Exhaust"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 1, 4, 3, 4, PackSummary.Tags.Exhaust));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/HermitPack.java
+++ b/src/main/java/thePackmaster/packs/HermitPack.java
@@ -16,7 +16,7 @@ public class HermitPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public HermitPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 3, 2));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 3, 3, 2));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/HighEnergyPack.java
+++ b/src/main/java/thePackmaster/packs/HighEnergyPack.java
@@ -15,7 +15,7 @@ public class HighEnergyPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public HighEnergyPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 3, 3, 2, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 3, 3, 2, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/InfestPack.java
+++ b/src/main/java/thePackmaster/packs/InfestPack.java
@@ -15,7 +15,7 @@ public class InfestPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public InfestPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 3, 2, 2));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 3, 2, 2));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/InstantDeathPack.java
+++ b/src/main/java/thePackmaster/packs/InstantDeathPack.java
@@ -15,7 +15,7 @@ public class InstantDeathPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public InstantDeathPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 3, PackSummary.Tags.Attacks));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 3, 2, 3, PackSummary.Tags.Attacks));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/InstantDeathPack.java
+++ b/src/main/java/thePackmaster/packs/InstantDeathPack.java
@@ -15,7 +15,7 @@ public class InstantDeathPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public InstantDeathPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 3, "Attacks"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 2, 3, PackSummary.Tags.Attacks));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/IntoTheBreachPack.java
+++ b/src/main/java/thePackmaster/packs/IntoTheBreachPack.java
@@ -16,7 +16,7 @@ public class IntoTheBreachPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public IntoTheBreachPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 3, 3, 3, 1));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(4, 3, 3, 3, 1));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/IntriguePack.java
+++ b/src/main/java/thePackmaster/packs/IntriguePack.java
@@ -16,7 +16,7 @@ public class IntriguePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public IntriguePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 2, 1));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 4, 2, 1));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/IroncladPack.java
+++ b/src/main/java/thePackmaster/packs/IroncladPack.java
@@ -15,7 +15,7 @@ public class IroncladPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public IroncladPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 3, 4, 2, PackSummary.Tags.Strength));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 2, 3, 4, 2, PackSummary.Tags.Strength));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/IroncladPack.java
+++ b/src/main/java/thePackmaster/packs/IroncladPack.java
@@ -15,7 +15,7 @@ public class IroncladPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public IroncladPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 3, 4, 2, "Strength"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 3, 4, 2, PackSummary.Tags.Strength));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/JockeyPack.java
+++ b/src/main/java/thePackmaster/packs/JockeyPack.java
@@ -15,7 +15,7 @@ public class JockeyPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public JockeyPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 4, 2, 4));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 2, 4, 2, 4));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/LegacyPack.java
+++ b/src/main/java/thePackmaster/packs/LegacyPack.java
@@ -16,7 +16,7 @@ public class LegacyPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public LegacyPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 2, 2, 3, 2, PackSummary.Tags.Exhaust));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(3, 2, 2, 3, 2, PackSummary.Tags.Exhaust));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/LegacyPack.java
+++ b/src/main/java/thePackmaster/packs/LegacyPack.java
@@ -16,7 +16,7 @@ public class LegacyPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public LegacyPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 2, 2, 3, 2, "Exhaust"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 2, 2, 3, 2, PackSummary.Tags.Exhaust));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/LockonPack.java
+++ b/src/main/java/thePackmaster/packs/LockonPack.java
@@ -17,7 +17,7 @@ public class LockonPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public LockonPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 3, 2, 4, "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 3, 2, 4, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/LockonPack.java
+++ b/src/main/java/thePackmaster/packs/LockonPack.java
@@ -17,7 +17,7 @@ public class LockonPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public LockonPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 3, 2, 4, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 2, 3, 2, 4, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/MadSciencePack.java
+++ b/src/main/java/thePackmaster/packs/MadSciencePack.java
@@ -15,7 +15,7 @@ public class MadSciencePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public MadSciencePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 5, 2, 3, "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 5, 2, 3, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/MadSciencePack.java
+++ b/src/main/java/thePackmaster/packs/MadSciencePack.java
@@ -15,7 +15,7 @@ public class MadSciencePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public MadSciencePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 5, 2, 3, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 5, 2, 3, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/MarisaPack.java
+++ b/src/main/java/thePackmaster/packs/MarisaPack.java
@@ -16,7 +16,7 @@ public class MarisaPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public MarisaPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 1, 3, 4, 3, "Exhaust", "Attacks"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 1, 3, 4, 3, PackSummary.Tags.Exhaust, PackSummary.Tags.Attacks));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/MarisaPack.java
+++ b/src/main/java/thePackmaster/packs/MarisaPack.java
@@ -16,7 +16,7 @@ public class MarisaPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public MarisaPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 1, 3, 4, 3, PackSummary.Tags.Exhaust, PackSummary.Tags.Attacks));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(4, 1, 3, 4, 3, PackSummary.Tags.Exhaust, PackSummary.Tags.Attacks));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/MetaPack.java
+++ b/src/main/java/thePackmaster/packs/MetaPack.java
@@ -15,7 +15,7 @@ public class MetaPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public MetaPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 2, 2, 3, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 2, 2, 3, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/MonsterHunterPack.java
+++ b/src/main/java/thePackmaster/packs/MonsterHunterPack.java
@@ -15,7 +15,7 @@ public class MonsterHunterPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public MonsterHunterPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 2, 3, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 2, 2, 3, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/OdditiesPack.java
+++ b/src/main/java/thePackmaster/packs/OdditiesPack.java
@@ -15,7 +15,7 @@ public class OdditiesPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public OdditiesPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 1, 5, 2, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 1, 5, 2, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/OrbPack.java
+++ b/src/main/java/thePackmaster/packs/OrbPack.java
@@ -16,7 +16,7 @@ public class OrbPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public OrbPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(1, 3, 4, 3, 4, "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(1, 3, 4, 3, 4, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/OrbPack.java
+++ b/src/main/java/thePackmaster/packs/OrbPack.java
@@ -16,7 +16,7 @@ public class OrbPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public OrbPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(1, 3, 4, 3, 4, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(1, 3, 4, 3, 4, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/OverwhelmingPack.java
+++ b/src/main/java/thePackmaster/packs/OverwhelmingPack.java
@@ -15,7 +15,7 @@ public class OverwhelmingPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public OverwhelmingPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 4, 3, 4));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 2, 4, 3, 4));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/PinnaclePack.java
+++ b/src/main/java/thePackmaster/packs/PinnaclePack.java
@@ -14,7 +14,7 @@ public class PinnaclePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public PinnaclePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 4, 1, 3));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 2, 4, 1, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/PixiePack.java
+++ b/src/main/java/thePackmaster/packs/PixiePack.java
@@ -23,7 +23,7 @@ public class PixiePack extends AbstractCardPack {
     private static AbstractCard.CardColor lastColor;
 
     public PixiePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 1, 4, 3, "Tokens"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 1, 4, 3, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/PixiePack.java
+++ b/src/main/java/thePackmaster/packs/PixiePack.java
@@ -23,7 +23,7 @@ public class PixiePack extends AbstractCardPack {
     private static AbstractCard.CardColor lastColor;
 
     public PixiePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 1, 4, 3, PackSummary.Tags.Tokens));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 1, 4, 3, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/PoisonPack.java
+++ b/src/main/java/thePackmaster/packs/PoisonPack.java
@@ -16,7 +16,7 @@ public class PoisonPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public PoisonPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(5, 1, 2, 2, 5, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(5, 1, 2, 2, 5, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/PoisonPack.java
+++ b/src/main/java/thePackmaster/packs/PoisonPack.java
@@ -16,7 +16,7 @@ public class PoisonPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public PoisonPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(5, 1, 2, 2, 5, "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(5, 1, 2, 2, 5, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/PrismaticPack.java
+++ b/src/main/java/thePackmaster/packs/PrismaticPack.java
@@ -16,7 +16,7 @@ public class PrismaticPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public PrismaticPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 3, 4, 2, 3, "Tokens"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 3, 4, 2, 3, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/PrismaticPack.java
+++ b/src/main/java/thePackmaster/packs/PrismaticPack.java
@@ -16,7 +16,7 @@ public class PrismaticPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public PrismaticPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 3, 4, 2, 3, PackSummary.Tags.Tokens));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(3, 3, 4, 2, 3, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/PsychicPack.java
+++ b/src/main/java/thePackmaster/packs/PsychicPack.java
@@ -16,7 +16,7 @@ public class PsychicPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public PsychicPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 3, 4, 4, "Exhaust"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 3, 4, 4, PackSummary.Tags.Exhaust));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/PsychicPack.java
+++ b/src/main/java/thePackmaster/packs/PsychicPack.java
@@ -16,7 +16,7 @@ public class PsychicPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public PsychicPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 3, 4, 4, PackSummary.Tags.Exhaust));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 2, 3, 4, 4, PackSummary.Tags.Exhaust));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/QuantaPack.java
+++ b/src/main/java/thePackmaster/packs/QuantaPack.java
@@ -15,7 +15,7 @@ public class QuantaPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public QuantaPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 4, 3, 4, 2));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 4, 3, 4, 2));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/QuietPack.java
+++ b/src/main/java/thePackmaster/packs/QuietPack.java
@@ -16,7 +16,7 @@ public class QuietPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public QuietPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 4, 4, 4, 2, PackSummary.Tags.Discard));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 4, 4, 4, 2, PackSummary.Tags.Discard));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/QuietPack.java
+++ b/src/main/java/thePackmaster/packs/QuietPack.java
@@ -16,7 +16,7 @@ public class QuietPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public QuietPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 4, 4, 4, 2, "Discard"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 4, 4, 4, 2, PackSummary.Tags.Discard));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ReplicatorsPack.java
+++ b/src/main/java/thePackmaster/packs/ReplicatorsPack.java
@@ -15,7 +15,7 @@ public class ReplicatorsPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ReplicatorsPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 5, 2, 5, PackSummary.Tags.Tokens));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 2, 5, 2, 5, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ReplicatorsPack.java
+++ b/src/main/java/thePackmaster/packs/ReplicatorsPack.java
@@ -15,7 +15,7 @@ public class ReplicatorsPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public ReplicatorsPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 5, 2, 5, "Tokens"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 5, 2, 5, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/RimworldPack.java
+++ b/src/main/java/thePackmaster/packs/RimworldPack.java
@@ -16,7 +16,7 @@ public class RimworldPack  extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public RimworldPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 3, 4, 2, 3));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(3, 3, 4, 2, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/RingOfPainPack.java
+++ b/src/main/java/thePackmaster/packs/RingOfPainPack.java
@@ -16,7 +16,7 @@ public class RingOfPainPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public RingOfPainPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 2, 3, 2, 3));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(4, 2, 3, 2, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/RipPack.java
+++ b/src/main/java/thePackmaster/packs/RipPack.java
@@ -15,7 +15,7 @@ public class RipPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public RipPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 2, 5, 2, "Exhaust", "Tokens"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 2, 5, 2, PackSummary.Tags.Exhaust, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/RipPack.java
+++ b/src/main/java/thePackmaster/packs/RipPack.java
@@ -15,7 +15,7 @@ public class RipPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public RipPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 2, 5, 2, PackSummary.Tags.Exhaust, PackSummary.Tags.Tokens));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 2, 5, 2, PackSummary.Tags.Exhaust, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SecretLevelPack.java
+++ b/src/main/java/thePackmaster/packs/SecretLevelPack.java
@@ -15,7 +15,7 @@ public class SecretLevelPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public SecretLevelPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 3, 2, 4, "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SecretLevelPack.java
+++ b/src/main/java/thePackmaster/packs/SecretLevelPack.java
@@ -15,7 +15,7 @@ public class SecretLevelPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public SecretLevelPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 3, 2, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SentinelPack.java
+++ b/src/main/java/thePackmaster/packs/SentinelPack.java
@@ -16,7 +16,7 @@ public class SentinelPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public SentinelPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 4, 2, 4, 2, "Stances"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 4, 2, 4, 2, PackSummary.Tags.Stances));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SentinelPack.java
+++ b/src/main/java/thePackmaster/packs/SentinelPack.java
@@ -16,7 +16,7 @@ public class SentinelPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public SentinelPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 4, 2, 4, 2, PackSummary.Tags.Stances));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 4, 2, 4, 2, PackSummary.Tags.Stances));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SerpentinePack.java
+++ b/src/main/java/thePackmaster/packs/SerpentinePack.java
@@ -17,7 +17,7 @@ public class SerpentinePack extends AbstractCardPack {
     //public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public SerpentinePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 1, 3, 2, 4, PackSummary.Tags.Stances, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 1, 3, 2, 4, PackSummary.Tags.Stances, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SerpentinePack.java
+++ b/src/main/java/thePackmaster/packs/SerpentinePack.java
@@ -17,7 +17,7 @@ public class SerpentinePack extends AbstractCardPack {
     //public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public SerpentinePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 1, 3, 2, 4, "Stances", "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 1, 3, 2, 4, PackSummary.Tags.Stances, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ShamanPack.java
+++ b/src/main/java/thePackmaster/packs/ShamanPack.java
@@ -16,7 +16,7 @@ public class ShamanPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public ShamanPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 3, 2, 1, 4, "Debuffs"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 3, 2, 1, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ShamanPack.java
+++ b/src/main/java/thePackmaster/packs/ShamanPack.java
@@ -16,7 +16,7 @@ public class ShamanPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public ShamanPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 3, 2, 1, 4, PackSummary.Tags.Debuffs));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(4, 3, 2, 1, 4, PackSummary.Tags.Debuffs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SilentPack.java
+++ b/src/main/java/thePackmaster/packs/SilentPack.java
@@ -15,7 +15,7 @@ public class SilentPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public SilentPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 3, 3, PackSummary.Tags.Discard));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 4, 3, 3, PackSummary.Tags.Discard));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SilentPack.java
+++ b/src/main/java/thePackmaster/packs/SilentPack.java
@@ -15,7 +15,7 @@ public class SilentPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public SilentPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 3, 3, "Discard"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 3, 3, PackSummary.Tags.Discard));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SneckoPack.java
+++ b/src/main/java/thePackmaster/packs/SneckoPack.java
@@ -18,7 +18,7 @@ public class SneckoPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public SneckoPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 1, 4, 3, 2));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(3, 1, 4, 3, 2));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SpheresPack.java
+++ b/src/main/java/thePackmaster/packs/SpheresPack.java
@@ -16,7 +16,7 @@ public class SpheresPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public SpheresPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 3, 1, 4, 3, "Debuffs", "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 3, 1, 4, 3, PackSummary.Tags.Debuffs, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SpheresPack.java
+++ b/src/main/java/thePackmaster/packs/SpheresPack.java
@@ -16,7 +16,7 @@ public class SpheresPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public SpheresPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(4, 3, 1, 4, 3, PackSummary.Tags.Debuffs, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(4, 3, 1, 4, 3, PackSummary.Tags.Debuffs, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/StatusPack.java
+++ b/src/main/java/thePackmaster/packs/StatusPack.java
@@ -18,7 +18,7 @@ public class StatusPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public StatusPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 5, 5, 3, "Exhaust", "Tokens"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 5, 5, 3, PackSummary.Tags.Exhaust, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/StatusPack.java
+++ b/src/main/java/thePackmaster/packs/StatusPack.java
@@ -18,7 +18,7 @@ public class StatusPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public StatusPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 5, 5, 3, PackSummary.Tags.Exhaust, PackSummary.Tags.Tokens));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 2, 5, 5, 3, PackSummary.Tags.Exhaust, PackSummary.Tags.Tokens));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/StrikesPack.java
+++ b/src/main/java/thePackmaster/packs/StrikesPack.java
@@ -15,7 +15,7 @@ public class StrikesPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public StrikesPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 1, 2, 4, 1, "Orbs", "Attacks"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 1, 2, 4, 1, PackSummary.Tags.Orbs, PackSummary.Tags.Attacks));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/StrikesPack.java
+++ b/src/main/java/thePackmaster/packs/StrikesPack.java
@@ -15,7 +15,7 @@ public class StrikesPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public StrikesPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 1, 2, 4, 1, PackSummary.Tags.Orbs, PackSummary.Tags.Attacks));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 1, 2, 4, 1, PackSummary.Tags.Orbs, PackSummary.Tags.Attacks));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SummonerSpellsPack.java
+++ b/src/main/java/thePackmaster/packs/SummonerSpellsPack.java
@@ -16,7 +16,7 @@ public class SummonerSpellsPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public SummonerSpellsPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 1, 4, 2, 3));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(3, 1, 4, 2, 3));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SummonsPack.java
+++ b/src/main/java/thePackmaster/packs/SummonsPack.java
@@ -17,7 +17,7 @@ public class SummonsPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public SummonsPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 2, 4, "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 2, 4, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/SummonsPack.java
+++ b/src/main/java/thePackmaster/packs/SummonsPack.java
@@ -17,7 +17,7 @@ public class SummonsPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public SummonsPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 2, 4, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 4, 2, 4, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/ThieveryPack.java
+++ b/src/main/java/thePackmaster/packs/ThieveryPack.java
@@ -15,7 +15,7 @@ public class ThieveryPack extends AbstractCardPack {
 	public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
 	public ThieveryPack() {
-		super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 4, 3, 3, PackSummary.Tags.Strength));
+		super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 2, 4, 3, 3, PackSummary.Tags.Strength));
 	}
 
 	@Override

--- a/src/main/java/thePackmaster/packs/ThieveryPack.java
+++ b/src/main/java/thePackmaster/packs/ThieveryPack.java
@@ -15,7 +15,7 @@ public class ThieveryPack extends AbstractCardPack {
 	public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
 	public ThieveryPack() {
-		super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 4, 3, 3, "Strength"));
+		super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 4, 3, 3, PackSummary.Tags.Strength));
 	}
 
 	@Override

--- a/src/main/java/thePackmaster/packs/TransmutationPack.java
+++ b/src/main/java/thePackmaster/packs/TransmutationPack.java
@@ -15,7 +15,7 @@ public class TransmutationPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public TransmutationPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(3, 3, 4, 3, 2));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(3, 3, 4, 3, 2));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/UtilityPack.java
+++ b/src/main/java/thePackmaster/packs/UtilityPack.java
@@ -16,7 +16,7 @@ public class UtilityPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public UtilityPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(2, 2, 5, 2, 3, "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(2, 2, 5, 2, 3, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/UtilityPack.java
+++ b/src/main/java/thePackmaster/packs/UtilityPack.java
@@ -16,7 +16,7 @@ public class UtilityPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public UtilityPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(2, 2, 5, 2, 3, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(2, 2, 5, 2, 3, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/WardenPack.java
+++ b/src/main/java/thePackmaster/packs/WardenPack.java
@@ -17,7 +17,7 @@ public class WardenPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public WardenPack() {
-        super(ID, NAME, DESC, AUTHOR,CREDITS, new AbstractCardPack.PackSummary(3, 2, 4, 2, 3));
+        super(ID, NAME, DESC, AUTHOR,CREDITS, new PackSummary(3, 2, 4, 2, 3));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/WarlockPack.java
+++ b/src/main/java/thePackmaster/packs/WarlockPack.java
@@ -21,7 +21,7 @@ public class WarlockPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public WarlockPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 2, 2, 3, 4, "Exhaust"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 2, 2, 3, 4, PackSummary.Tags.Exhaust));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/WarlockPack.java
+++ b/src/main/java/thePackmaster/packs/WarlockPack.java
@@ -21,7 +21,7 @@ public class WarlockPack extends AbstractCardPack {
     public static final String CREDITS = UI_STRINGS.TEXT[3];
 
     public WarlockPack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 2, 2, 3, 4, PackSummary.Tags.Exhaust));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(3, 2, 2, 3, 4, PackSummary.Tags.Exhaust));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/WarriorPack.java
+++ b/src/main/java/thePackmaster/packs/WarriorPack.java
@@ -15,7 +15,7 @@ public class WarriorPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public WarriorPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 1, 3, 2, "Debuffs", "Attacks"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 1, 3, 2, PackSummary.Tags.Debuffs, PackSummary.Tags.Attacks));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/WarriorPack.java
+++ b/src/main/java/thePackmaster/packs/WarriorPack.java
@@ -15,7 +15,7 @@ public class WarriorPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public WarriorPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 2, 1, 3, 2, PackSummary.Tags.Debuffs, PackSummary.Tags.Attacks));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 2, 1, 3, 2, PackSummary.Tags.Debuffs, PackSummary.Tags.Attacks));
         hatHidesHair = true;
     }
 

--- a/src/main/java/thePackmaster/packs/WatcherPack.java
+++ b/src/main/java/thePackmaster/packs/WatcherPack.java
@@ -15,7 +15,7 @@ public class WatcherPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public WatcherPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 3, 3, 4, 2));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 3, 3, 4, 2));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/WeaponsPack.java
+++ b/src/main/java/thePackmaster/packs/WeaponsPack.java
@@ -15,7 +15,7 @@ public class WeaponsPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public WeaponsPack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(4, 1, 2, 3, 1));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(4, 1, 2, 3, 1));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/WitchesStrikePack.java
+++ b/src/main/java/thePackmaster/packs/WitchesStrikePack.java
@@ -15,7 +15,7 @@ public class WitchesStrikePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
     public static final String CREDITS = UI_STRINGS.TEXT[3];
     public WitchesStrikePack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 2, 4, 3, 3, PackSummary.Tags.Orbs));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new PackSummary(3, 2, 4, 3, 3, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/WitchesStrikePack.java
+++ b/src/main/java/thePackmaster/packs/WitchesStrikePack.java
@@ -15,7 +15,7 @@ public class WitchesStrikePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
     public static final String CREDITS = UI_STRINGS.TEXT[3];
     public WitchesStrikePack() {
-        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 2, 4, 3, 3, "Orbs"));
+        super(ID, NAME, DESC, AUTHOR, CREDITS, new AbstractCardPack.PackSummary(3, 2, 4, 3, 3, PackSummary.Tags.Orbs));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/WomanInBluePack.java
+++ b/src/main/java/thePackmaster/packs/WomanInBluePack.java
@@ -15,7 +15,7 @@ public class WomanInBluePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public WomanInBluePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 4, 4, 2, "Exhaust"));
+        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 4, 4, 2, PackSummary.Tags.Exhaust));
     }
 
     @Override

--- a/src/main/java/thePackmaster/packs/WomanInBluePack.java
+++ b/src/main/java/thePackmaster/packs/WomanInBluePack.java
@@ -15,7 +15,7 @@ public class WomanInBluePack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public WomanInBluePack() {
-        super(ID, NAME, DESC, AUTHOR, new AbstractCardPack.PackSummary(2, 2, 4, 4, 2, PackSummary.Tags.Exhaust));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 2, 4, 4, 2, PackSummary.Tags.Exhaust));
     }
 
     @Override

--- a/src/main/java/thePackmaster/summaries/PackSummaryDisplay.java
+++ b/src/main/java/thePackmaster/summaries/PackSummaryDisplay.java
@@ -5,6 +5,7 @@ import com.megacrit.cardcrawl.localization.UIStrings;
 import org.apache.commons.lang3.StringUtils;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.packs.AbstractCardPack;
+
 import java.util.stream.Collectors;
 
 public class PackSummaryDisplay {
@@ -43,10 +44,10 @@ public class PackSummaryDisplay {
             return StringUtils.repeat("[RatingStarIcon] ", value) + StringUtils.repeat("[RatingDarkStarIcon] ", 5 - value);
     }
 
-    private static String getTagString(String tag) {
-        if (!uiStrings.TEXT_DICT.containsKey(tag)) {
+    private static String getTagString(AbstractCardPack.PackSummary.Tags tag) {
+        if (!uiStrings.TEXT_DICT.containsKey(tag.name())) {
             throw new RuntimeException("Unrecognized tag: " + tag);
         }
-        return (!tag.equals(AbstractCardPack.PackSummary.NONE_TAG) ? "#y" : "") + uiStrings.TEXT_DICT.get(tag);
+        return (!tag.equals(AbstractCardPack.PackSummary.Tags.None) ? "#y" : "") + uiStrings.TEXT_DICT.get(tag.name());
     }
 }


### PR DESCRIPTION
The old system just took in strings and would just crash if the given tag string didn't exist, making this system a little stricter via the use of enums should be good at guiding people to tag correctly and gives an easy overview of the current tags.