### PR TITLE
change ascension max hp loss

### DIFF
--- a/src/main/java/thePackmaster/ThePackmaster.java
+++ b/src/main/java/thePackmaster/ThePackmaster.java
@@ -132,7 +132,7 @@ public class ThePackmaster extends CustomPlayer {
 
     @Override
     public int getAscensionMaxHPLoss() {
-        return 8;
+        return 4;
     }
 
     @Override


### PR DESCRIPTION
packmaster has the same asc 0 max hp as defect yet the asc 14 max hp loss is twice as much as defect, i bet whoever copied over protemplate forgot to change it