### PR TITLE
Balance tweaks: Flourish, Conjure Defends, Talk to the Claw

### DIFF
--- a/src/main/java/thePackmaster/cards/basicspack/ConjureDefends.java
+++ b/src/main/java/thePackmaster/cards/basicspack/ConjureDefends.java
@@ -1,8 +1,6 @@
 package thePackmaster.cards.basicspack;
 
-import com.evacipated.cardcrawl.mod.stslib.StSLib;
 import com.evacipated.cardcrawl.mod.stslib.actions.common.RefundAction;
-import com.megacrit.cardcrawl.actions.common.GainEnergyAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -19,6 +17,7 @@ public class ConjureDefends extends AbstractPackmasterCard {
 
     public ConjureDefends() {
         super(ID, -1, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.SELF, "basics");
+        this.isEthereal = true;
         this.exhaust = true;
         this.cardsToPreview = new Defend();
         this.cardsToPreview.rawDescription += CardCrawlGame.languagePack.getUIString(SpireAnniversary5Mod.makeID("DuplicateModifier")).TEXT[2];
@@ -33,6 +32,6 @@ public class ConjureDefends extends AbstractPackmasterCard {
     }
 
     public void upp(){
-        this.cardsToPreview.upgrade();
+        this.isEthereal = false;
     }
 }

--- a/src/main/java/thePackmaster/cards/clawpack/TalkToTheClaw.java
+++ b/src/main/java/thePackmaster/cards/clawpack/TalkToTheClaw.java
@@ -20,7 +20,7 @@ public class TalkToTheClaw extends AbstractClawCard {
     public TalkToTheClaw() {
         super(ID, 1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
         baseDamage = 5;
-        baseMagicNumber = magicNumber = 3;
+        baseMagicNumber = magicNumber = 2;
         tags.add(CLAW);
         exhaust = true;
     }

--- a/src/main/java/thePackmaster/cards/evenoddpack/Flourish.java
+++ b/src/main/java/thePackmaster/cards/evenoddpack/Flourish.java
@@ -14,7 +14,7 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 public class Flourish extends AbstractEvenOddCard{
     public final static String ID = makeID(Flourish.class.getSimpleName());
     private static final int MAGIC = 3;
-    private static final int UMAGIC = 2;
+    private static final int UMAGIC = 1;
     private static final int COST = 1;
     private static final CardType TYPE = CardType.POWER;
     private static final CardRarity RARITY = CardRarity.UNCOMMON;

--- a/src/main/resources/anniv5Resources/localization/eng/basicspack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/basicspack/Cardstrings.json
@@ -46,8 +46,8 @@
   },
   "${ModID}:ConjureDefends": {
     "NAME": "Conjure Defends",
-    "DESCRIPTION": "Add a *Defend to your hand and ${ModID}:Modify it: \"Play this X times\". Refund 1. Exhaust.",
-    "UPGRADE_DESCRIPTION": "Add a *Defend+ to your hand and ${ModID}:Modify it: \"Play this X times\". Refund 1. Exhaust."
+    "DESCRIPTION": "Ethereal. NL Add a *Defend to your hand and ${ModID}:Modify it: \"Play this X times\". Refund 1. Exhaust.",
+    "UPGRADE_DESCRIPTION": "Add a *Defend to your hand and ${ModID}:Modify it: \"Play this X times\". Refund 1. Exhaust."
 
   },
   "${ModID}:SimpleTrick": {


### PR DESCRIPTION
These are the balance tweaks we discussed.
* Flourish has the Plated Armor/Healing upgrade reduced by 1, as discussed. I'd still happily pick it.
* Conjure Defends upgrades from Ethereal to not Ethereal -- our original idea of only adding the Refund when upgraded means you can't play the Defend you get, so that doesn't really work. So I made a different change to the upgrade, since the upgrade made the card just too high value (almost as good as Reinforced Body+, and you get the super Defend to play later). With this change, you have to accept a less efficient initial block in return for getting the supers Defend. Ethereal also means you can't hold onto the unupgraded version if you want to wait and play it with more energy -- meaningful when you draw this and can only afford to spend 1 or 2 energy on it.
* Talk to the Claw has its block reduced by 1. This is the kind of gentle nerf I was looking for, since Talk to the Claw was extremely strong and will still be very good with this change. Plus this change means the numbers now match Talk to the Hand, which is nice symmetry with the other cards in the pack that reference base game cards.

Leaving this up for you to review and merge in case there's anything you want to discuss.

Cosmos Command pack is in the expansion mod, so the changes for it are at https://github.com/erasels/Packmaster-Expansion-Packs/pull/7/files.