### PR TITLE
Core relics: prevent Gem of Unity from spawning if you're playing with a number of packs other than the default (e.g. all packs mode or a custom draft setup)

### DIFF
--- a/src/main/java/thePackmaster/relics/GemOfUnity.java
+++ b/src/main/java/thePackmaster/relics/GemOfUnity.java
@@ -86,6 +86,13 @@ public class GemOfUnity extends AbstractPackmasterRelic {
         super.onPlayCard(c, m);
     }
 
+    @Override
+    public boolean canSpawn() {
+        // Gem of Unity is balanced around there being 7 packs in the pool, so if you're playing with a different number
+        // (e.g. by using all packs mode or by using a custom draft setup), we prevent it from spawning
+        return SpireAnniversary5Mod.currentPoolPacks.size() == SpireAnniversary5Mod.PACKS_PER_RUN;
+    }
+
     public String getUpdatedDescription() {
         StringBuilder desc = new StringBuilder(DESCRIPTIONS[0]);
         if (AbstractDungeon.isPlayerInDungeon()) {


### PR DESCRIPTION
This came up as feedback in the Steam comments and I agreed that having Gem of Unity spawn for nonstandard numbers of packs didn't make sense.

Leaving this for you to merge in case you want to discuss or look for alternate approaches.