### PR TITLE
Fix a few issues with Vexation pack and Plated Armor keyword

### DIFF
--- a/src/main/java/thePackmaster/cards/colorlesspack/Manifest.java
+++ b/src/main/java/thePackmaster/cards/colorlesspack/Manifest.java
@@ -23,7 +23,7 @@ public class Manifest extends AbstractColorlessPackCard {
 
     public void use(AbstractPlayer p, AbstractMonster m) {
         dmg(m, AbstractGameAction.AttackEffect.FIRE);
-        atb(new SelectCardsAction(AbstractDungeon.player.discardPile.group, cardStrings.EXTENDED_DESCRIPTION[0], abstractCard -> (abstractCard.costForTurn >= 0 && abstractCard.costForTurn <= 1) || abstractCard.freeToPlayOnce,
+        atb(new SelectCardsAction(AbstractDungeon.player.discardPile.group, cardStrings.EXTENDED_DESCRIPTION[0], abstractCard -> (abstractCard.cost >= 0 && abstractCard.cost <= 1) || abstractCard.freeToPlayOnce,
                 (cards) -> {
                     for (AbstractCard q : cards) {
                         att(new PlayFromDiscardAction(q));

--- a/src/main/java/thePackmaster/patches/colorlesspack/GhostPatches.java
+++ b/src/main/java/thePackmaster/patches/colorlesspack/GhostPatches.java
@@ -7,6 +7,7 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.GameActionManager;
 import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardQueueItem;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
@@ -24,7 +25,8 @@ public class GhostPatches {
     public static class GhostSubvertPlay {
         @SpireInsertPatch(locator = Locator.class)
         public static void Insert(GameActionManager __instance) {
-            AbstractCard c = __instance.cardQueue.get(0).card;
+            CardQueueItem cqi = __instance.cardQueue.get(0);
+            AbstractCard c = cqi.card;
             if (c != null) {
                 if (CardModifierManager.hasModifier(c, IsGhostModifier.ID)) {
                     if (__instance.cardQueue.get(0).monster == null) {
@@ -39,10 +41,7 @@ public class GhostPatches {
                     mod.ghost.target_x = Settings.WIDTH / 2F;
                     mod.ghost.target_y = Settings.HEIGHT / 2F;
 
-                    mod.ghost.dontTriggerOnUseCard = false;
-                    if (!mod.ghost.canUse(AbstractDungeon.player, null)) {
-                        mod.ghost.dontTriggerOnUseCard = true;
-                    }
+                    mod.ghost.dontTriggerOnUseCard = !cqi.autoplayCard && !mod.ghost.canUse(AbstractDungeon.player, null);
 
 
                     AbstractDungeon.actionManager.addToTop(new WaitMoreAction(0.25F));

--- a/src/main/resources/anniv5Resources/localization/eng/evenoddpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/evenoddpack/Cardstrings.json
@@ -30,7 +30,7 @@
   },
   "${ModID}:Flourish": {
     "NAME": "Flourish",
-    "DESCRIPTION": "Gain !M! Plated Armor.",
+    "DESCRIPTION": "Gain !M! ${ModID}:Plated_Armor.",
     "EXTENDED_DESCRIPTION": [" NL ", "${ModID}:Even:", " Heal !M! HP.", "${ModID}:Odd:", " Gain [E] ."]
   },
   "${ModID}:EvenOddAppend": {

--- a/src/main/resources/anniv5Resources/localization/eng/womaninbluepack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/womaninbluepack/Cardstrings.json
@@ -21,9 +21,9 @@
   },
   "${ModID}:MetallicVial": {
     "NAME": "Metallic Vial",
-    "DESCRIPTION": "Choose: Gain 4 Plated Armor, Gain 3 Thorns, or Gain 2 Artifact. NL Exhaust.",
-    "UPGRADE_DESCRIPTION": "Choose: Gain 4 Plated Armor, Gain 3 Thorns, or Gain 2 Artifact. NL stslib:Exhaustive !stslib:ex!.",
-    "EXTENDED_DESCRIPTION": ["Gain 4 Plated Armor.", "Gain 3 Thorns.","Gain 2 Artifact."]
+    "DESCRIPTION": "Choose: Gain 4 ${ModID}:Plated_Armor, Gain 3 Thorns, or Gain 2 Artifact. NL Exhaust.",
+    "UPGRADE_DESCRIPTION": "Choose: Gain ${ModID}:Plated_Armor, Gain 3 Thorns, or Gain 2 Artifact. NL stslib:Exhaustive !stslib:ex!.",
+    "EXTENDED_DESCRIPTION": ["Gain 4 ${ModID}:Plated_Armor.", "Gain 3 Thorns.","Gain 2 Artifact."]
   },
   "${ModID}:QuickBrew": {
     "NAME": "Quick Brew",


### PR DESCRIPTION
* Vexation pack: fix Ghost not doing anything when played by effects like Distilled Chaos or Havoc when you have zero energy
* Various packs: use the keyword for Plated Armor
* Vexation pack: fix Manifest being able to play cards that were temporarily discounted previously in the turn (but that shouldn't be playable because they've entered the discard pile and the discount is now gone)