### PR TITLE
Balance changes and bug fixes

### DIFF
--- a/src/main/java/thePackmaster/actions/gowiththeflowpack/FlowAction.java
+++ b/src/main/java/thePackmaster/actions/gowiththeflowpack/FlowAction.java
@@ -80,7 +80,8 @@ public class FlowAction extends AbstractGameAction {
                         }
                     }
                 }
-                AbstractDungeon.actionManager.addToTop(new ApplyPowerAction(AbstractDungeon.player, AbstractDungeon.player, new FlowPower(AbstractDungeon.player, cardsDiscarded.size())));
+                int drawAmount = cardsDiscarded.size() / 2;
+                AbstractDungeon.actionManager.addToTop(new ApplyPowerAction(AbstractDungeon.player, AbstractDungeon.player, new FlowPower(AbstractDungeon.player, drawAmount)));
             }
         }
         tickDuration();

--- a/src/main/java/thePackmaster/cards/creativitypack/MakeshiftShield.java
+++ b/src/main/java/thePackmaster/cards/creativitypack/MakeshiftShield.java
@@ -15,7 +15,7 @@ public class MakeshiftShield extends AbstractCreativityCard {
 
     public MakeshiftShield() {
         super(ID, 1, CardType.POWER, CardRarity.UNCOMMON, CardTarget.SELF);
-        magicNumber = baseMagicNumber = 3;
+        magicNumber = baseMagicNumber = 2;
     }
 
     @Override

--- a/src/main/java/thePackmaster/cards/creativitypack/Mimicry.java
+++ b/src/main/java/thePackmaster/cards/creativitypack/Mimicry.java
@@ -47,7 +47,7 @@ public class Mimicry extends AbstractCreativityCard {
                     }
                     return o;
                 }).collect(Collectors.toCollection(ArrayList::new));
-                addToBot(new FlexibleDiscoveryAction(JediUtil.createCardsForDiscovery(tmpGrp), false));
+                addToTop(new FlexibleDiscoveryAction(JediUtil.createCardsForDiscovery(tmpGrp), false));
                 isDone = true;
             }
         });

--- a/src/main/java/thePackmaster/cards/creativitypack/Souvenirs.java
+++ b/src/main/java/thePackmaster/cards/creativitypack/Souvenirs.java
@@ -29,20 +29,27 @@ public class Souvenirs extends AbstractCreativityCard {
 
     @Override
     public void upp() {
+        ArrayList<AbstractCard> previewCards = MultiCardPreview.multiCardPreview.get(this);
+        if (previewCards != null) {
+            for (AbstractCard c : MultiCardPreview.multiCardPreview.get(this)) {
+                c.upgrade();
+            }
+        }
     }
 
     @Override
     public void use(AbstractPlayer abstractPlayer, AbstractMonster abstractMonster) {
-        for (int i = 0; i <= timesUpgraded; i++)
-        {
-            ArrayList<AbstractCard> list = new ArrayList<>();
-            Smite smite = new Smite();
-            Safety safety = new Safety();
-            CardModifierManager.addModifier(smite, new DrawCardModifier());
-            CardModifierManager.addModifier(safety, new DrawCardModifier());
-            list.add(smite);
-            list.add(safety);
-            addToBot(new FlexibleDiscoveryAction(list, false));
+        ArrayList<AbstractCard> list = new ArrayList<>();
+        Smite smite = new Smite();
+        Safety safety = new Safety();
+        CardModifierManager.addModifier(smite, new DrawCardModifier());
+        CardModifierManager.addModifier(safety, new DrawCardModifier());
+        if (this.upgraded) {
+            smite.upgrade();
+            safety.upgrade();
         }
+        list.add(smite);
+        list.add(safety);
+        addToBot(new FlexibleDiscoveryAction(list, false));
     }
 }

--- a/src/main/java/thePackmaster/cards/creativitypack/StrikingStrike.java
+++ b/src/main/java/thePackmaster/cards/creativitypack/StrikingStrike.java
@@ -19,22 +19,20 @@ public class StrikingStrike extends AbstractCreativityCard {
     public final static String ID = makeID(StrikingStrike.class.getSimpleName());
 
     public StrikingStrike() {
-        super(ID, 1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
+        super(ID, 2, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
         baseDamage = damage = 6;
         tags.add(CardTags.STRIKE);
     }
 
     @Override
     public void upp() {
+        this.upgradeBaseCost(1);
     }
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
         addToBot(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_DIAGONAL));
         CardGroup cards = JediUtil.filterCardsForDiscovery(c -> c.hasTag(CardTags.STRIKE) && !c.hasTag(CardTags.HEALING) && c.rarity != CardRarity.SPECIAL && c.rarity != CardRarity.BASIC);
-        if (upgraded) {
-            cards.group.forEach(AbstractCard::upgrade);
-        }
         addToBot(new FlexibleDiscoveryAction(JediUtil.createCardsForDiscovery(cards), selectedCard -> {
             CardModifierManager.addModifier(selectedCard, new ExhaustMod());
             },

--- a/src/main/java/thePackmaster/cards/gemspack/EnergyGem.java
+++ b/src/main/java/thePackmaster/cards/gemspack/EnergyGem.java
@@ -14,7 +14,7 @@ public class EnergyGem extends AbstractGemsCard {
     public final static String ID = makeID("EnergyGem");
 
     public EnergyGem() {
-        super(ID, 0, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.SELF);
+        super(ID, 0, CardType.SKILL, CardRarity.RARE, CardTarget.SELF);
     }
 
     @Override

--- a/src/main/java/thePackmaster/cards/gowiththeflowpack/Aqueducts.java
+++ b/src/main/java/thePackmaster/cards/gowiththeflowpack/Aqueducts.java
@@ -13,7 +13,7 @@ public class Aqueducts extends AbstractHydrologistCard {
 
     public Aqueducts() {
         super(ID, 2, CardType.POWER, CardRarity.UNCOMMON, CardTarget.NONE, Subtype.WATER);
-        magicNumber = baseMagicNumber = 2;
+        magicNumber = baseMagicNumber = 3;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/gowiththeflowpack/Hydraulics.java
+++ b/src/main/java/thePackmaster/cards/gowiththeflowpack/Hydraulics.java
@@ -12,7 +12,7 @@ public class Hydraulics extends AbstractHydrologistCard {
 
     public Hydraulics() {
         super(ID, 1, CardType.ATTACK, CardRarity.COMMON, CardTarget.ENEMY, Subtype.WATER);
-        damage = baseDamage = 9;
+        damage = baseDamage = 11;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/thePackmaster/cards/monsterhunterpack/HuntingInstincts.java
+++ b/src/main/java/thePackmaster/cards/monsterhunterpack/HuntingInstincts.java
@@ -27,8 +27,8 @@ public class HuntingInstincts extends AbstractMonsterHunterCard {
     }
 
     @Override
-    public void applyPowers() {
-        super.applyPowers();
+    public void applyPowersToBlock() {
+        super.applyPowersToBlock();
 
         if(hasHuntTarget()) {
             block *= 2;
@@ -37,7 +37,7 @@ public class HuntingInstincts extends AbstractMonsterHunterCard {
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
-        addToBot(new GainBlockAction(p, block * (hasHuntTarget()? 2 : 1)));
+        addToBot(new GainBlockAction(p, block));
     }
 
     public boolean hasHuntTarget() {

--- a/src/main/java/thePackmaster/cards/rippack/FragileShrug.java
+++ b/src/main/java/thePackmaster/cards/rippack/FragileShrug.java
@@ -15,7 +15,7 @@ public class FragileShrug extends AbstractRipCard implements OnRipInterface{
 
     public FragileShrug() {
         super(ID, 1, CardType.SKILL, CardRarity.COMMON, CardTarget.NONE);
-        baseBlock = block = 7;
+        baseBlock = block = 6;
         baseMagicNumber = magicNumber = 1;
         CardModifierManager.addModifier(this, new RippableModifier());
     }

--- a/src/main/java/thePackmaster/cards/rippack/Inspiration.java
+++ b/src/main/java/thePackmaster/cards/rippack/Inspiration.java
@@ -22,7 +22,7 @@ public class Inspiration extends AbstractRipCard {
 
 
     public Inspiration() {
-        super(ID, 0, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.NONE);
+        super(ID, 1, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.NONE);
         baseDamage = damage = 12;
         baseMagicNumber = magicNumber = 12;
         exhaust = true;

--- a/src/main/java/thePackmaster/cards/rippack/Inspiration.java
+++ b/src/main/java/thePackmaster/cards/rippack/Inspiration.java
@@ -23,8 +23,6 @@ public class Inspiration extends AbstractRipCard {
 
     public Inspiration() {
         super(ID, 1, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.NONE);
-        baseDamage = damage = 12;
-        baseMagicNumber = magicNumber = 12;
         exhaust = true;
         CardModifierManager.addModifier(this, new RippableModifier());
     }

--- a/src/main/java/thePackmaster/cards/rippack/Inspiration.java
+++ b/src/main/java/thePackmaster/cards/rippack/Inspiration.java
@@ -30,7 +30,7 @@ public class Inspiration extends AbstractRipCard {
     @Override
     public void applyPowers() {
         super.applyPowers();
-        int statusAndArtCardsInExhaust = AbstractDungeon.player.exhaustPile.group.stream().filter(card -> isArtCard(card) || card.type == CardType.STATUS).collect(Collectors.toList()).size();
+        int statusAndArtCardsInExhaust = (int) AbstractDungeon.player.exhaustPile.group.stream().filter(card -> isArtCard(card) || card.type == CardType.STATUS).count();
         rawDescription = upgraded ? cardStrings.UPGRADE_DESCRIPTION : cardStrings.DESCRIPTION;
         rawDescription += cardStrings.EXTENDED_DESCRIPTION[0] + statusAndArtCardsInExhaust;
         if (statusAndArtCardsInExhaust == 1) {
@@ -49,7 +49,7 @@ public class Inspiration extends AbstractRipCard {
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        int statusAndArtCardsInExhaust = AbstractDungeon.player.exhaustPile.group.stream().filter(card -> isArtCard(card) || card.type == CardType.STATUS).collect(Collectors.toList()).size();
+        int statusAndArtCardsInExhaust = (int) AbstractDungeon.player.exhaustPile.group.stream().filter(card -> isArtCard(card) || card.type == CardType.STATUS).count();
 
         AbstractGameEffect off = InspirationEffect.Off();
         atb(new VFXAction(off));

--- a/src/main/java/thePackmaster/cards/utilitypack/GreaterHex.java
+++ b/src/main/java/thePackmaster/cards/utilitypack/GreaterHex.java
@@ -15,8 +15,8 @@ import thePackmaster.vfx.utilitypack.HexEffect;
 
 public class GreaterHex extends AbstractPackmasterCard {
     public static final String ID = SpireAnniversary5Mod.makeID("GreaterHex");
-    private static final int COST = 1;
-    private static final int UPGRADE_COST = 0;
+    private static final int COST = 2;
+    private static final int UPGRADE_COST = 1;
     private static final int STATS = 2;
 
     public GreaterHex() {

--- a/src/main/java/thePackmaster/powers/replicatorspack/IterativeDesignPower.java
+++ b/src/main/java/thePackmaster/powers/replicatorspack/IterativeDesignPower.java
@@ -26,7 +26,7 @@ public class IterativeDesignPower extends AbstractPackmasterPower implements Clo
 
 
     public IterativeDesignPower(AbstractCreature owner, int amount) {
-        super(POWER_ID, NAME, AbstractPower.PowerType.BUFF, true, owner, amount);
+        super(POWER_ID, NAME, AbstractPower.PowerType.BUFF, false, owner, amount);
 
     }
 

--- a/src/main/resources/anniv5Resources/localization/eng/creativitypack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/creativitypack/Cardstrings.json
@@ -33,7 +33,7 @@
   },
   "${ModID}:StrikingStrike": {
     "NAME": "Striking Strike",
-    "DESCRIPTION": "{@@}Deal !D! damage. NL Discover a{!Upgrades!|>0=n Upgraded} strike. It Exhausts when played and costs 0 this turn."
+    "DESCRIPTION": "{@@}Deal !D! damage. NL Discover a strike. It Exhausts when played and costs 0 this turn."
   },
   "${ModID}:AccumulativeStrike": {
     "NAME": "Accumulative Strike",

--- a/src/main/resources/anniv5Resources/localization/eng/creativitypack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/creativitypack/Cardstrings.json
@@ -17,7 +17,7 @@
   },
   "${ModID}:Souvenirs": {
     "NAME": "Souvenirs",
-    "DESCRIPTION": "{@@}Create a *Smite or *Safety in hand. It draws a card. {!Upgrades!|>0= NL Do it again.}"
+    "DESCRIPTION": "{@@}Create a *Smite{!Upgrades!|>0=+} or *Safety{!Upgrades!|>0=+} in hand. It draws a card."
   },
   "${ModID}:Mimicry": {
     "NAME": "Mimicry",

--- a/src/main/resources/anniv5Resources/localization/eng/gowiththeflowpack/Keywordstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/gowiththeflowpack/Keywordstrings.json
@@ -4,6 +4,6 @@
     "NAMES": [
       "flow"
     ],
-    "DESCRIPTION": "When you Flow, you may discard any number of cards. Draw that many at the start of your next turn."
+    "DESCRIPTION": "When you Flow, you may discard any number of cards. Draw half that many at the start of your next turn."
   }
 ]

--- a/src/main/resources/anniv5Resources/localization/eng/legacypack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/legacypack/Cardstrings.json
@@ -42,7 +42,7 @@
   },
   "${ModID}:SlimeSpray": {
     "NAME": "Slime Spray",
-    "DESCRIPTION": "Retain. NL Deal !D! damage, apply !M! Poison, and apply Slow to ALL enemies."
+    "DESCRIPTION": "Retain. NL Deal !D! damage, apply !M! Poison, and apply *Slow to ALL enemies."
   },
   "${ModID}:StickStrike": {
     "NAME": "Stick Strike",

--- a/src/main/resources/anniv5Resources/localization/eng/utilitypack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/utilitypack/Cardstrings.json
@@ -32,12 +32,12 @@
   },
   "${ModID}:LesserHex": {
     "NAME": "Lesser Hex",
-    "DESCRIPTION": "Apply !M! Weak and !M! Vulnerable. NL Enemy loses !M! Strength. NL Add a *Greater\u00a0Hex to your discard pile. NL Exhaust.",
+    "DESCRIPTION": "Apply !M! Weak. NL Apply !M! Vulnerable. NL Enemy loses !M! Strength. NL Add a *Greater\u00a0Hex to your discard pile. NL Exhaust.",
     "UPGRADE_DESCRIPTION": "Apply !M! Weak and !M! Vulnerable. NL Enemy loses !M! Strength. NL Add a *Greater\u00a0Hex+ to your discard pile. NL Exhaust."
   },
   "${ModID}:GreaterHex": {
     "NAME": "Greater Hex",
-    "DESCRIPTION": "Apply !M! Weak and !M! Vulnerable. NL Enemy loses !M! Strength. NL Exhaust."
+    "DESCRIPTION": "Apply !M! Weak. NL Apply !M! Vulnerable. NL Enemy loses !M! Strength. NL Exhaust."
   },
   "${ModID}:Conjuration": {
     "NAME": "Conjuration",


### PR DESCRIPTION
Leaving this for you to take a quick look over and merge -- we discussed all the balance changes, but there are enough changes that it makes sense.

### Balance changes
Gems pack: change Citrine to rare
Rip pack: reduce Fragile Shrug block by 1
Rip pack: increase Inspiration cost by 1
Utility pack: increase Greater Hex cost by 1
Go With The Flow pack: change Flow to draw next turn equal to half the number of discarded cards (instead of equal to the number of discarded cards)
Go With The Flow pack: increase Hydraulics damage by 2
Go With The Flow pack: increase Aqueducts damage by 1
Creativity pack: reduce Makeshift Shield block by 1
Creativity pack: change Souvenirs upgrade to upgrade the created card (instead of creating an additional card)
Creativity pack: change Striking Strike to cost 2 and to upgrade to cost 1

### Fixes
Creativity pack: make the animation for Mimicry more consistent with other cards that discover a new card
Monster Hunter pack: fix Hunting Instincts showing the wrong block amount when you hold the card and hover it over the playing area
Replicators pack: fix Iterative Design being incorrectly marked as turn-based
Utility pack: tweak text formatting for Lesser Hex and Greater Hex to have each effect on its own line
Legacy pack: add keyword highlighting for Slow