### PR TITLE
Creativity pack: change Accumulative Strike to always count statuses for its damage gain, change its upgrade to increase the damage gain from created cards by 1, and lower its base damage by 4 (from 12 to 8)

### DIFF
--- a/src/main/java/thePackmaster/cardmodifiers/creativitypack/AccumulativeDamageModifier.java
+++ b/src/main/java/thePackmaster/cardmodifiers/creativitypack/AccumulativeDamageModifier.java
@@ -4,15 +4,24 @@ import basemod.abstracts.AbstractCardModifier;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import thePackmaster.cards.creativitypack.AccumulativeStrike;
 import thePackmaster.util.creativitypack.JediUtil;
 
-public class AccumulativeDamageModifier extends AbstractCardModifier {
+import static thePackmaster.SpireAnniversary5Mod.makeID;
 
-    private final int damageRamp;
+public class AccumulativeDamageModifier extends AbstractCardModifier {
+    public static final String ID = makeID(AccumulativeDamageModifier.class.getSimpleName());
+
+    private int damageRamp;
 
     public AccumulativeDamageModifier(int dmg)
     {
         damageRamp = dmg;
+    }
+
+    @Override
+    public String identifier(AbstractCard card) {
+        return ID;
     }
 
     @Override
@@ -23,12 +32,16 @@ public class AccumulativeDamageModifier extends AbstractCardModifier {
     @Override
     public float modifyDamage(float damage, DamageInfo.DamageType type, AbstractCard card, AbstractMonster target) {
         float retVal = damage;
-        retVal += JediUtil.cardsCreatedThisCombat.stream().filter(c -> c.type != AbstractCard.CardType.STATUS || card.upgraded).count() * damageRamp;
+        retVal += JediUtil.cardsCreatedThisCombat.size() * damageRamp;
         return retVal;
     }
 
     @Override
     public AbstractCardModifier makeCopy() {
         return new AccumulativeDamageModifier(damageRamp);
+    }
+
+    public void setDamageRamp(int damageRamp) {
+        this.damageRamp = damageRamp;
     }
 }

--- a/src/main/java/thePackmaster/cards/creativitypack/AccumulativeStrike.java
+++ b/src/main/java/thePackmaster/cards/creativitypack/AccumulativeStrike.java
@@ -18,12 +18,14 @@ public class AccumulativeStrike extends AbstractCreativityCard {
         super(ID, 2, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
         magicNumber = baseMagicNumber = 2;
         CardModifierManager.addModifier(this, new AccumulativeDamageModifier(magicNumber));
-        baseDamage = damage = 12;
+        baseDamage = damage = 8;
         tags.add(CardTags.STRIKE);
     }
 
     @Override
     public void upp() {
+        upgradeMagicNumber(1);
+        CardModifierManager.getModifiers(this, AccumulativeDamageModifier.ID).forEach(m -> ((AccumulativeDamageModifier)m).setDamageRamp((this.magicNumber)));
     }
 
     @Override

--- a/src/main/resources/anniv5Resources/localization/eng/creativitypack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/creativitypack/Cardstrings.json
@@ -37,7 +37,7 @@
   },
   "${ModID}:AccumulativeStrike": {
     "NAME": "Accumulative Strike",
-    "DESCRIPTION": "{@@}Deal !D! damage. NL Deals !M! additional damage for ALL your {!Upgrades!|0= non-Status} created cards."
+    "DESCRIPTION": "{@@}Deal !D! damage. NL Deals !M! additional damage for ALL your created cards."
   },
   "${ModID}:BrushModalTypeChoice": {
     "NAME": "You should never see this",


### PR DESCRIPTION
This got discussed right after you went to bed. Vex suggested it as a way to make the card less awkward (removing "non-Status" on upgrade was something people didn't expect and felt weird when compared to other cards like it, e.g. Perfected Strike). I agreed, Jedi agreed, I offered to make the PR.

Overall this is intended to be neither clearly a buff or a nerf. It will be better in fights where lots of statuses get created, but a bit slower to ramp up in other fights. It will still ramp up quickly enough to do a lot of damage, but the reduced base damage will make it a bit riskier to take early on when Nob or Lagavulin can end your run. If the upgrade turns out to be too good, we can reduce the base damage or make some other change, but it's worth having a more straightforward upgrade.

Leaving this one up for you to merge mostly so you can take a quick look over the Card Modifier stuff and make sure I didn't miss anything obvious.