### PR TITLE
Bellord swap and various buffs

### DIFF
--- a/src/main/java/thePackmaster/cards/bellordpack/Cuckoo.java
+++ b/src/main/java/thePackmaster/cards/bellordpack/Cuckoo.java
@@ -13,7 +13,7 @@ public class Cuckoo extends AbstractBellordCard {
     // intellij stuff power, self, uncommon, , , , , 13, 
 
     public Cuckoo() {
-        super(ID, 1, CardType.POWER, CardRarity.RARE, CardTarget.SELF);
+        super(ID, 1, CardType.POWER, CardRarity.UNCOMMON, CardTarget.SELF);
         baseMagicNumber = magicNumber = 13;
     }
 

--- a/src/main/java/thePackmaster/cards/bellordpack/LikeClockwork.java
+++ b/src/main/java/thePackmaster/cards/bellordpack/LikeClockwork.java
@@ -12,7 +12,7 @@ public class LikeClockwork extends AbstractBellordCard {
     // intellij stuff power, self, rare, , , , , 5, 2
 
     public LikeClockwork() {
-        super(ID, 0, CardType.POWER, CardRarity.UNCOMMON, CardTarget.SELF);
+        super(ID, 1, CardType.POWER, CardRarity.RARE, CardTarget.SELF);
         baseMagicNumber = magicNumber = 4;
     }
 
@@ -21,6 +21,6 @@ public class LikeClockwork extends AbstractBellordCard {
     }
 
     public void upp() {
-        upgradeMagicNumber(2);
+        isInnate = true;
     }
 }

--- a/src/main/java/thePackmaster/cards/colorlesspack/Ghost.java
+++ b/src/main/java/thePackmaster/cards/colorlesspack/Ghost.java
@@ -29,7 +29,7 @@ public class Ghost extends AbstractColorlessPackCard implements StartupCard {
 
     public Ghost() {
         super(ID, 1, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.ENEMY);
-        baseMagicNumber = magicNumber = 12;
+        baseMagicNumber = magicNumber = 13;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
@@ -78,6 +78,6 @@ public class Ghost extends AbstractColorlessPackCard implements StartupCard {
     }
 
     public void upp() {
-        upgradeMagicNumber(3);
+        upgradeMagicNumber(4);
     }
 }

--- a/src/main/java/thePackmaster/cards/odditiespack/ZaHando.java
+++ b/src/main/java/thePackmaster/cards/odditiespack/ZaHando.java
@@ -21,7 +21,7 @@ public class ZaHando extends AbstractOdditiesCard {
 
     public ZaHando() {
         super(ID, 1, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
-        baseDamage = 13;
+        baseDamage = 14;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/resources/anniv5Resources/localization/eng/bellordpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/bellordpack/Cardstrings.json
@@ -37,7 +37,8 @@
   },
   "${ModID}:LikeClockwork": {
     "NAME": "Like Clockwork",
-    "DESCRIPTION": "At the end of your turn, gain !M! Block for each Curse or Status card in your hand."
+    "DESCRIPTION": "At the end of your turn, gain !M! Block for each Curse or Status card in your hand.",
+    "UPGRADE_DESCRIPTION": "Innate. NL At the end of your turn, gain !M! Block for each Curse or Status card in your hand."
   },
   "${ModID}:SavedByTheBell": {
     "NAME": "Saved by the Bell",


### PR DESCRIPTION
I picked the low winrate cards off for +1 value, and nerfed (mostly) Belord pack with a rarity swap. Two innate upgrades make sense for the pack since it ups in value to get your actual cards before your curses.