### PR TITLE
Bulwark pack: rework the pack, moving many of the cards to the new Indomitable pack

### DIFF
--- a/src/main/java/thePackmaster/packs/BulwarkPack.java
+++ b/src/main/java/thePackmaster/packs/BulwarkPack.java
@@ -1,15 +1,15 @@
 package thePackmaster.packs;
 
-import com.megacrit.cardcrawl.cards.blue.GeneticAlgorithm;
+import com.megacrit.cardcrawl.cards.blue.ConserveBattery;
+import com.megacrit.cardcrawl.cards.blue.Equilibrium;
 import com.megacrit.cardcrawl.cards.blue.SteamBarrier;
 import com.megacrit.cardcrawl.cards.green.AfterImage;
-import com.megacrit.cardcrawl.cards.green.Blur;
-import com.megacrit.cardcrawl.cards.green.PiercingWail;
+import com.megacrit.cardcrawl.cards.green.Backflip;
+import com.megacrit.cardcrawl.cards.purple.Sanctity;
 import com.megacrit.cardcrawl.cards.purple.SpiritShield;
-import com.megacrit.cardcrawl.cards.purple.WaveOfTheHand;
-import com.megacrit.cardcrawl.cards.red.BodySlam;
-import com.megacrit.cardcrawl.cards.red.FeelNoPain;
+import com.megacrit.cardcrawl.cards.purple.Swivel;
 import com.megacrit.cardcrawl.cards.red.Juggernaut;
+import com.megacrit.cardcrawl.cards.red.SecondWind;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.localization.UIStrings;
 import thePackmaster.SpireAnniversary5Mod;
@@ -24,20 +24,20 @@ public class BulwarkPack extends AbstractCardPack {
     public static final String AUTHOR = UI_STRINGS.TEXT[2];
 
     public BulwarkPack() {
-        super(ID, NAME, DESC, AUTHOR, new PackSummary(2, 5, 1, 4, 4, PackSummary.Tags.Exhaust));
+        super(ID, NAME, DESC, AUTHOR, new PackSummary(1, 5, 2, 3, 4, PackSummary.Tags.Exhaust));
         this.hatHidesHair = true;
     }
 
     @Override
     public ArrayList<String> getCards() {
         ArrayList<String> cards = new ArrayList<>();
-        cards.add(BodySlam.ID);
-        cards.add(PiercingWail.ID);
+        cards.add(Backflip.ID);
+        cards.add(ConserveBattery.ID);
         cards.add(SteamBarrier.ID);
-        cards.add(FeelNoPain.ID);
-        cards.add(Blur.ID);
-        cards.add(GeneticAlgorithm.ID);
-        cards.add(WaveOfTheHand.ID);
+        cards.add(Swivel.ID);
+        cards.add(Equilibrium.ID);
+        cards.add(Sanctity.ID);
+        cards.add(SecondWind.ID);
         cards.add(Juggernaut.ID);
         cards.add(AfterImage.ID);
         cards.add(SpiritShield.ID);


### PR DESCRIPTION
Bulwark still has the powerful Juggernaut plus After Image combo, but its other cards now focus more on block combined with drawing cards and hand size benefits.
![bulwark](https://github.com/erasels/PackmasterCharacter/assets/62083413/18b8bbe6-8412-436d-ae81-c6fbce62473d)
