### PR TITLE
Warden pack changes

### DIFF
--- a/src/main/java/thePackmaster/actions/wardenpack/AnticipationAction.java
+++ b/src/main/java/thePackmaster/actions/wardenpack/AnticipationAction.java
@@ -11,8 +11,11 @@ import java.util.Iterator;
 import com.megacrit.cardcrawl.actions.common.DrawCardAction;
 
 public class AnticipationAction extends AbstractGameAction {
-    public AnticipationAction() {
+    private boolean upgraded;
+
+    public AnticipationAction(boolean upgraded) {
         this.duration = 0.001F;
+        this.upgraded = upgraded;
     }
 
     public void update() {
@@ -23,7 +26,16 @@ public class AnticipationAction extends AbstractGameAction {
 
             while(var1.hasNext()) {
                 AbstractCard c = (AbstractCard)var1.next();
-                truecost += Wiz.getLogicalCardCost(c);
+
+                int nextcost = Wiz.getLogicalCardCost(c);
+
+                if (upgraded)
+                    truecost += nextcost;
+                else
+                {
+                    if (nextcost > truecost)
+                        truecost = nextcost;
+                }
             }
 
             if (truecost > 0)

--- a/src/main/java/thePackmaster/cards/wardenpack/Anticipation.java
+++ b/src/main/java/thePackmaster/cards/wardenpack/Anticipation.java
@@ -14,15 +14,11 @@ public class Anticipation extends AbstractWardenCard {
 
     public Anticipation() {
         super(ID, 1, CardType.SKILL, CardRarity.UNCOMMON, CardTarget.SELF);
-        this.baseMagicNumber = 1;
-        this.magicNumber = this.baseMagicNumber;
+        baseMagicNumber = 2;
+        magicNumber = baseMagicNumber;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
-        Wiz.atb(new DrawCardAction(this.magicNumber, new AnticipationAction()));
-    }
-
-    public void upp() {
-        upgradeMagicNumber(1);
+        Wiz.atb(new DrawCardAction(this.magicNumber, new AnticipationAction(upgraded)));
     }
 }

--- a/src/main/java/thePackmaster/cards/wardenpack/ForceBolt.java
+++ b/src/main/java/thePackmaster/cards/wardenpack/ForceBolt.java
@@ -1,9 +1,12 @@
 package thePackmaster.cards.wardenpack;
 
+import basemod.helpers.CardModifierManager;
+import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.PersistFields;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.VulnerablePower;
+import thePackmaster.cardmodifiers.energyandechopack.EchoMod;
 import thePackmaster.util.Wiz;
 
 import static thePackmaster.SpireAnniversary5Mod.makeID;
@@ -11,10 +14,8 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 public class ForceBolt extends AbstractWardenCard {
     public final static String ID = makeID("ForceBolt");
 
-    private static final int DAMAGE = 5;
-    private static final int DAMAGE_UPGRADE = 2;
+    private static final int DAMAGE = 3;
     private static final int MAGIC_BASE = 1;
-    private static final int MAGIC_UP = 1;
 
     public ForceBolt() {
         super(ID, 0, CardType.ATTACK, CardRarity.UNCOMMON, CardTarget.ENEMY);
@@ -28,7 +29,6 @@ public class ForceBolt extends AbstractWardenCard {
     }
 
     public void upp() {
-        upgradeDamage(DAMAGE_UPGRADE);
-        upgradeMagicNumber(MAGIC_UP);
+        PersistFields.setBaseValue(this, 2);
     }
 }

--- a/src/main/java/thePackmaster/cards/wardenpack/PierceVeil.java
+++ b/src/main/java/thePackmaster/cards/wardenpack/PierceVeil.java
@@ -17,7 +17,7 @@ import static thePackmaster.SpireAnniversary5Mod.makeID;
 public class PierceVeil extends AbstractWardenCard {
     public final static String ID = makeID("PierceVeil");
 
-    private static final int DAMAGE = 5;
+    private static final int DAMAGE = 8;
     private static final int DAMAGE_UPGRADE = 3;
 
     public PierceVeil() {

--- a/src/main/java/thePackmaster/cards/wardenpack/RiskOfBlades.java
+++ b/src/main/java/thePackmaster/cards/wardenpack/RiskOfBlades.java
@@ -4,7 +4,6 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.cards.DamageInfo;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
-import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import thePackmaster.util.Wiz;
 
@@ -19,36 +18,21 @@ public class RiskOfBlades extends AbstractWardenCard {
     public RiskOfBlades() {
         super(ID, 2, CardType.ATTACK, CardRarity.COMMON, CardTarget.ENEMY);
         baseDamage = DAMAGE;
-        magicNumber = baseMagicNumber = 0;
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {
+        int hitnum = 1;
 
-        magicNumber = this.baseMagicNumber = hitAmount(3)+1;
+        if (!Wiz.drawPile().isEmpty() && (Wiz.drawPile().getTopCard().type == CardType.ATTACK))
+            hitnum = 3;
 
-        for (int a = 0; a < this.magicNumber; a++)
+        for (int a = 0; a < hitnum; a++)
         Wiz.atb(new DamageAction(m, new DamageInfo(p, this.damage, this.damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_VERTICAL));
     }
 
-    public int hitAmount(int hits)
-    {
-        int a = 0;
-
-        for(int i = 0; i < Math.min(hits, AbstractDungeon.player.drawPile.size()); ++i) {
-            if (Wiz.p().drawPile.group.get(AbstractDungeon.player.drawPile.size() - i - 1).type == CardType.ATTACK)
-            a++;
-        }
-
-        return a;
-    }
-
-    public void applyPowers() {
-        magicNumber = baseMagicNumber = hitAmount(3);
-
-        super.applyPowers();
-
-        rawDescription = cardStrings.DESCRIPTION + (magicNumber == 1 ? cardStrings.EXTENDED_DESCRIPTION[0] : cardStrings.EXTENDED_DESCRIPTION[1]);
-        initializeDescription();
+    @Override
+    public void triggerOnGlowCheck() {
+        glowColor = ((!Wiz.drawPile().isEmpty() && (Wiz.drawPile().getTopCard().type == CardType.ATTACK)) ? GOLD_BORDER_GLOW_COLOR : BLUE_BORDER_GLOW_COLOR);
     }
 
     public void upp() {

--- a/src/main/java/thePackmaster/cards/wardenpack/Stall.java
+++ b/src/main/java/thePackmaster/cards/wardenpack/Stall.java
@@ -18,7 +18,7 @@ public class Stall extends AbstractWardenCard {
 
     public Stall() {
         super(ID, 1, CardType.SKILL, CardRarity.COMMON, CardTarget.SELF);
-        baseBlock = 7;
+        baseBlock = 8;
         baseMagicNumber = 2;
         magicNumber = baseMagicNumber;
     }

--- a/src/main/resources/anniv5Resources/localization/eng/wardenpack/Cardstrings.json
+++ b/src/main/resources/anniv5Resources/localization/eng/wardenpack/Cardstrings.json
@@ -9,8 +9,7 @@
   },
   "${ModID}:RiskOfBlades": {
     "NAME": "Risk Of Blades",
-    "DESCRIPTION": "Deal !D! damage. NL Repeat for each Attack in the top 3 cards of your draw pile.",
-    "EXTENDED_DESCRIPTION": [" NL (Hits !M! more time.)", " NL (Hits !M! more times.)"]
+    "DESCRIPTION": "Deal !D! damage, thrice if the top card of your draw pile is an Attack."
   },
   "${ModID}:Crossroads": {
     "NAME": "Crossroads",
@@ -18,8 +17,8 @@
   },
   "${ModID}:Anticipation": {
     "NAME": "Anticipation",
-    "DESCRIPTION": "Draw 1 card. NL Gain Strength equal to its cost.",
-    "UPGRADE_DESCRIPTION": "Draw !M! cards. NL Gain Strength equal to their cost."
+    "DESCRIPTION": "Draw !M! cards. NL Gain Strength equal to the higher of their costs.",
+    "UPGRADE_DESCRIPTION": "Draw !M! cards. NL Gain Strength equal to their total cost."
   },
   "${ModID}:Prediction": {
     "NAME": "Prediction",
@@ -27,7 +26,8 @@
   },
   "${ModID}:ForceBolt": {
     "NAME": "Force Bolt",
-    "DESCRIPTION": "Deal !D! damage. NL Apply !M! Vulnerable."
+    "DESCRIPTION": "Deal !D! damage. NL Apply !M! Vulnerable.",
+    "UPGRADE_DESCRIPTION": "Deal !D! damage. NL Apply !M! Vulnerable. NL stslib:Persist !stslib:persist!."
   },
   "${ModID}:Enigmancy": {
     "NAME": "Enigmancy",


### PR DESCRIPTION
- Anticipation draws 2 by default but picks highest cost of drawn cards, Force bolt deals less damage upgrades to Persist 2, Pierce Veil deals 3 more damage, Risk of Blades simpler deals 1-3 hits, Stall gives 1 more Block.