### PR TITLE
Creativity pack: fix Accumulative Strike damage not increasing when cards are created

### DIFF
--- a/src/main/java/thePackmaster/SpireAnniversary5Mod.java
+++ b/src/main/java/thePackmaster/SpireAnniversary5Mod.java
@@ -139,8 +139,7 @@ public class SpireAnniversary5Mod implements
         PostExhaustSubscriber,
         OnPlayerTurnStartSubscriber,
         OnCreateDescriptionSubscriber,
-        PostRenderSubscriber,
-        OnCreateCardInterface {
+        PostRenderSubscriber {
 
     public static final Logger logger = LogManager.getLogger("Packmaster");
 
@@ -1390,11 +1389,6 @@ public class SpireAnniversary5Mod implements
             }
         }
         return currentRaw;
-    }
-
-    @Override
-    public void onCreateCard(AbstractCard c) {
-        JediUtil.onGenerateCardMidcombat(c);
     }
 
     public static class Enums {

--- a/src/main/java/thePackmaster/patches/creativitypack/AccumulativeStrikePatch.java
+++ b/src/main/java/thePackmaster/patches/creativitypack/AccumulativeStrikePatch.java
@@ -1,0 +1,15 @@
+package thePackmaster.patches.creativitypack;
+
+import com.evacipated.cardcrawl.mod.stslib.StSLib;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import thePackmaster.util.creativitypack.JediUtil;
+
+@SpirePatch(clz = StSLib.class, method = "onCreateCard", paramtypez = {AbstractCard.class})
+public class AccumulativeStrikePatch {
+    @SpirePostfixPatch
+    public static void onCreateCard(AbstractCard c) {
+        JediUtil.onGenerateCardMidcombat(c);
+    }
+}


### PR DESCRIPTION
The issue is that `OnCreateCardInterface` isn't a subscriber, but the main mod file tried to use it like one. Looking at StSLib, it only works on relics/powers/cards/monsters. https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/StSLib.java#L226