### PR TITLE
Custom runs: fix the Shiny modifier not working with Packmaster

### DIFF
--- a/src/main/java/thePackmaster/SpireAnniversary5Mod.java
+++ b/src/main/java/thePackmaster/SpireAnniversary5Mod.java
@@ -30,10 +30,12 @@ import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.daily.mods.Shiny;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.CardHelper;
 import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.helpers.ModHelper;
 import com.megacrit.cardcrawl.localization.*;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.powers.ArtifactPower;
@@ -64,6 +66,7 @@ import thePackmaster.patches.CompendiumPatches;
 import thePackmaster.patches.MainMenuUIPatch;
 import thePackmaster.patches.MetricsPatches;
 import thePackmaster.patches.RenderBaseGameCardPackTopTextPatches;
+import thePackmaster.patches.compatibility.InfiniteSpirePatch;
 import thePackmaster.patches.contentcreatorpack.DisableCountingStartOfTurnDrawPatch;
 import thePackmaster.patches.marisapack.AmplifyPatches;
 import thePackmaster.patches.odditiespack.PackmasterFoilPatches;
@@ -1099,6 +1102,16 @@ public class SpireAnniversary5Mod implements
         //Calling this to fill the card pool after the currentPoolPacks are filled
         selectedCards = true;
         CardCrawlGame.dungeon.initializeCardPools();
+    }
+
+    public static void initializeCardPools() {
+        CardCrawlGame.dungeon.initializeCardPools();
+        if (ModHelper.isModEnabled(Shiny.ID)) {
+            CardGroup group = AbstractDungeon.getEachRare();
+            for (AbstractCard c : group.group)
+                AbstractDungeon.player.masterDeck.addToTop(c);
+        }
+        InfiniteSpirePatch.generateQuestsIfInfiniteSpireIsLoaded();
     }
 
     private static void loadAndCheckSummaries() {

--- a/src/main/java/thePackmaster/patches/OpeningRunScreenPatch.java
+++ b/src/main/java/thePackmaster/patches/OpeningRunScreenPatch.java
@@ -3,7 +3,6 @@ package thePackmaster.patches;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.evacipated.cardcrawl.modthespire.patcher.Expectation;
 import com.evacipated.cardcrawl.modthespire.patcher.PatchingException;
-import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.events.AbstractEvent;
@@ -14,7 +13,6 @@ import javassist.expr.Expr;
 import javassist.expr.FieldAccess;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.ThePackmaster;
-import thePackmaster.patches.compatibility.InfiniteSpirePatch;
 
 import java.util.ArrayList;
 
@@ -31,8 +29,7 @@ public class OpeningRunScreenPatch {
                         SpireAnniversary5Mod.logger.info("Vex's All Packs Override Enabled. Skipping intro screen");
                         SpireAnniversary5Mod.currentPoolPacks.clear();
                         SpireAnniversary5Mod.currentPoolPacks.addAll(SpireAnniversary5Mod.allPacks);
-                        CardCrawlGame.dungeon.initializeCardPools();
-                        InfiniteSpirePatch.generateQuestsIfInfiniteSpireIsLoaded();
+                        SpireAnniversary5Mod.initializeCardPools();
                     } else {
                         SpireAnniversary5Mod.logger.info("Packmaster is Ready To Do Thing");
                         SpireAnniversary5Mod.openedStarterScreen = false;

--- a/src/main/java/thePackmaster/screens/PackSetupScreen.java
+++ b/src/main/java/thePackmaster/screens/PackSetupScreen.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 import thePackmaster.SpireAnniversary5Mod;
 import thePackmaster.packs.AbstractCardPack;
 import thePackmaster.patches.MetricsPatches;
-import thePackmaster.patches.compatibility.InfiniteSpirePatch;
 import thePackmaster.summaries.PackSummaryDisplay;
 import thePackmaster.ui.FixedModLabeledToggleButton.FixedModLabeledToggleButton;
 
@@ -208,8 +207,7 @@ public class PackSetupScreen extends CustomScreen {
                     currentPoolPacks.sort(Comparator.comparing((pack)->pack.name));
                     SpireAnniversary5Mod.selectedCards = true;
                     editPotionPool(PotionHelper.potions);
-                    CardCrawlGame.dungeon.initializeCardPools();
-                    InfiniteSpirePatch.generateQuestsIfInfiniteSpireIsLoaded();
+                    SpireAnniversary5Mod.initializeCardPools();
                 }
                 break;
             case DRAFTING:


### PR DESCRIPTION
Also centralized the logic for initializing card pools and other related stuff after setting up packs (previously it was duplicated between the all packs code and the pack setup screen).