### PR TITLE
Oddities pack: increase Midnight Strike upgrade damage by 1, so that there's a consistent 3x multiplier between the normal damage and the special case damage

### DIFF
--- a/src/main/java/thePackmaster/cards/odditiespack/MidnightStrike.java
+++ b/src/main/java/thePackmaster/cards/odditiespack/MidnightStrike.java
@@ -54,7 +54,7 @@ public class MidnightStrike extends AbstractOdditiesCard {
     }
 
     public void upp() {
-        upgradeDamage(3);
+        upgradeDamage(4);
         upgradeSecondDamage(12);
     }
 }


### PR DESCRIPTION
In addition to the numerological benefit, this had a pretty weak upgrade for a rare and Midnight Strike isn't picked that much in the first place, so a buff should be fine.

I made sure Vex was okay with it.