### PR TITLE
Fix Amplify costs not rendering in Compendium sometimes

### DIFF
--- a/src/main/java/thePackmaster/cards/marisapack/AmplifyCard.java
+++ b/src/main/java/thePackmaster/cards/marisapack/AmplifyCard.java
@@ -3,6 +3,7 @@ package thePackmaster.cards.marisapack;
 import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
 import thePackmaster.patches.marisapack.AmplifyPatches;
@@ -20,6 +21,7 @@ public interface AmplifyCard {
      *                 This should be used in applyPowers/calculateCardDamage
      */
     default boolean shouldAmplify(AbstractCard thisCard) {
+        if (!CardCrawlGame.isInARun()) return true;
         int cardCost = Wiz.getLogicalCardCost(thisCard);
         return EnergyPanel.totalCount >= cardCost + ((AmplifyCard)thisCard)._costLogic();
     }
@@ -46,7 +48,7 @@ public interface AmplifyCard {
 
     // Includes amplify cost negation logic
     default int _costLogic() {
-        if(Wiz.p() != null && Wiz.p().hasPower(FreeAmplifyPower.POWER_ID)) {
+        if(CardCrawlGame.isInARun() && Wiz.p() != null && Wiz.p().hasPower(FreeAmplifyPower.POWER_ID)) {
             return 0;
         }
         return getAmplifyCost();

--- a/src/main/java/thePackmaster/patches/marisapack/AmplifyPatches.java
+++ b/src/main/java/thePackmaster/patches/marisapack/AmplifyPatches.java
@@ -10,6 +10,7 @@ import com.megacrit.cardcrawl.actions.utility.UseCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.EnergyManager;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
@@ -189,7 +190,7 @@ public class AmplifyPatches {
 
         private static int costLogic(AbstractCard c) {
             int ampCost = ((AmplifyCard) c)._costLogic();
-            if (ampCost > 0 && ampCost + Wiz.getLogicalCardCost(c) <= EnergyPanel.totalCount) {
+            if (!CardCrawlGame.isInARun() || (ampCost > 0 && ampCost + Wiz.getLogicalCardCost(c) <= EnergyPanel.totalCount)) {
                 return ampCost;
             } else if (ampCost == 0) { // Doesn't support reducing amplify cost as opposed to making it free, however that effect is not planned or implemented
                 return 0;


### PR DESCRIPTION
Now Amplify costs always render by default if the player is not in a run, and they always render unmodified (i.e. ignoring FreeAmplifyPower) while not in a run